### PR TITLE
[codex] Revise git commit skill workflow

### DIFF
--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-skill
-description: v0.2.0 - Draft, split, and execute scoped Git commits with issue traceability and structured Why/What/Impact/Tests/Refs bodies; use when preparing final commits, reviewing commit wording, or enforcing repo commit conventions.
+description: v0.2.1 - Draft, split, and execute atomic scoped Git commits with issue traceability and structured Why/What/Impact/Tests/Refs bodies; use when preparing final commits, reviewing commit wording, or enforcing repo commit conventions.
 ---
 
 # Git Commit Skill
@@ -32,17 +32,19 @@ Out of scope:
 
 - Preserve traceability from task or issue to commit.
 - Produce clear, reviewable commit messages that explain why the change exists.
-- Keep staging scope explicit and conservative.
-- Treat full commit execution as the default outcome for real commit-stage work,
-  not as a separate opt-in after drafting.
+- Treat commits as verified save points, not as one final packaging step.
+- Keep changes small, atomic, reviewable, and revertible.
+- Use the existing message template as the output format while borrowing git
+  workflow discipline from `git-workflow-and-versioning`.
 
 ## Bundled Resources
 
 - `references/commit-message-standard.md`
   Read when writing the subject, body, or examples for the commit message.
 - `references/commit-execution-policy.md`
-  Read when deciding split boundaries, staging policy, issue-gate interaction,
-  or worktree/sandbox handling.
+  Read when deciding atomic commit boundaries, save-point cadence, staging
+  policy, pre-commit hygiene, issue-gate interaction, or worktree/sandbox
+  handling.
 
 ## Concrete Trigger Examples
 
@@ -60,9 +62,13 @@ Use this skill for prompts such as:
   another convention
 - commit body format: exact `Why / What / Impact / Tests / Refs`
 - execution mode: full commit execution for normal commit-stage work
+- split policy: atomic save-point commits, based on
+  `commit-execution-policy.md`
+- size policy: target about 100 changed lines, accept about 300 for one
+  logical change, split around 1000 or more unless generated or inseparable
 - traceability mode: run `issue-gate-skill` first when the repo requires issue
   tracking
-- staging policy: stage only AI-authored, approved, in-scope files
+- staging policy: stage only approved, in-scope files
 - unrelated changes: ignore by default
 - mixed authorship files: ask once before staging
 - low-risk traceability fallback: `Refs: - n/a`
@@ -76,22 +82,27 @@ Use this skill for prompts such as:
      - split planning without execution
    - If the user asks for a normal commit-stage outcome, default to full
      execution.
-2. Confirm upstream workflow state.
-   - Treat the recommended order as:
-     `worktree -> issue -> implement -> issue-gate -> commit`
-   - This skill is the final commit-stage closer, not the place where task
-     scope is first defined.
-   - If implementation drifted materially from the issue or agreed scope,
-     require that traceability to be repaired before finalizing the commit.
+2. Inspect branch, worktree, and current diff.
+   - Read `references/commit-execution-policy.md`.
+   - Run the branch/worktree check described there.
+   - Treat commits as save points in this order:
+     `worktree -> issue -> implement verified slice -> issue-gate -> commit`.
+   - If the diff is mixed, keep unrelated changes out of the staged scope.
 3. Run pre-commit traceability gate when required.
    - Use `issue-gate-skill` with `input_mode=auto-infer-first`.
    - If the gate returns `BLOCK`, stop commit output and surface the blocker.
    - If the gate returns `refs_line`, prefer that value in `Refs`.
-4. Review the diff and propose split boundaries.
-   - Separate logically independent changes.
-   - Keep one commit focused on one coherent task or delivery slice.
-   - Read `references/commit-execution-policy.md` when split or staging
-     boundaries are ambiguous.
+4. Size and split the work before staging.
+   - Target about 100 changed lines per commit or PR.
+   - Treat about 300 changed lines as acceptable only for one logical change.
+   - Treat about 1000 changed lines or more as a split trigger unless the diff
+     is generated or structurally inseparable.
+   - Separate feature work, refactors, formatting, dependencies, generated
+     artifacts, and unrelated docs into different commits.
+   - Use stack, file-group, horizontal, or vertical splitting when the diff is
+     too large.
+   - Keep tightly coupled code, tests, and docs together when they form one
+     reviewable and revertible save point.
 5. Resolve the subject line.
    - Choose the commit type and optional scope.
    - Write one sentence in imperative mood.
@@ -107,10 +118,14 @@ Use this skill for prompts such as:
    - wording-only or split-only request:
      - return the draft message and split advice without staging or committing
    - full execution:
-     - stage only approved in-scope files
+     - commit one verified slice at a time
+     - stage only the approved in-scope files for that slice
+     - run the required pre-commit hygiene checks from
+       `commit-execution-policy.md`
      - write the final message to a file
      - run `git commit -F <file>`
-     - report commit hash, staged file scope, and traceability
+     - report commit hash, staged file scope, traceability, and remaining
+       unstaged scope
 8. Report the result.
    - Include the final message or draft preview.
    - Include whether execution happened.
@@ -127,6 +142,8 @@ Use this skill for prompts such as:
 - split_required: yes | no
 - rationale:
 - staged_scope:
+- size_assessment:
+- split_strategy:
 
 ## Commit Message
 - subject:
@@ -143,10 +160,19 @@ Use this skill for prompts such as:
 ## Guardrails
 
 - Do not stage unrelated changes by default.
-- Do not commit files that mix AI-authored and unrelated user changes without
+- Do not commit files that mix in-scope work and unrelated user changes without
   confirmation.
 - Do not continue to commit execution when `issue-gate-skill` returns `BLOCK`.
 - Do not write single-line commit messages.
+- Do not squash independent save points into one broad commit merely for speed.
+- Do not accumulate verified increments into a giant end-of-task commit.
+- Do not split tightly coupled code, tests, and docs when they form one
+  reviewable and revertible slice.
+- Do not mix feature work, refactors, formatting-only changes, generated
+  artifacts, or dependency changes unless the execution policy says they are
+  inseparable.
+- Do not treat size limits as hard math; use them as review and rollback risk
+  signals.
 - Do not use `"not requested"` as the explanation for missing tests; use a real
   operational reason.
 - Do not require an AI session identifier unless the repository explicitly

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Commit"
-  short_description: "v0.2.0 - Draft and execute scoped Git commits"
-  default_prompt: "Use $git-commit-skill to review the current diff, confirm traceability, and draft or execute the final commit with the required Why/What/Impact/Tests/Refs structure."
+  short_description: "v0.2.1 - Execute save-point Git commits"
+  default_prompt: "Use $git-commit-skill to review the current diff, apply save-point commit discipline, split by size and concern, confirm traceability, and execute commits with the required Why/What/Impact/Tests/Refs structure."

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
@@ -1,7 +1,12 @@
 # Commit Execution Policy
 
-Use this reference when deciding staging scope, split boundaries, traceability,
-or whether the skill should execute the commit directly.
+Use this reference for everything about commit execution except the final
+message template.
+
+This policy intentionally follows
+`development-skill-pack/supporting-skills/git-workflow-and-versioning`.
+`commit-message-standard.md` is only the source of truth for the final
+`Why / What / Impact / Tests / Refs` message format.
 
 ## Default Execution Rule
 
@@ -10,20 +15,55 @@ or whether the skill should execute the commit directly.
   is clear and approved.
 - Stop at draft-only output only when the user explicitly asks for wording-only
   help, split planning, or message review without execution.
+- If the current diff contains multiple independent save points, stage and
+  commit them one at a time.
+- Do not accumulate verified increments into one giant end-of-task commit.
+
+## Commit Early, Commit Often
+
+Use the save point pattern from `git-workflow-and-versioning`:
+
+```text
+Implement slice -> Test -> Verify -> Commit -> Next slice
+```
+
+Commits are save points. A completed, verified increment should normally be
+committed before starting the next independent increment. If the next change
+breaks something, the last known-good commit should still be easy to return to.
+
+This does not mean committing broken checkpoints. A save point must be coherent,
+reviewable, and backed by an honest verification note.
 
 ## Recommended Upstream Order
 
 Treat the preferred task order as:
 
 ```text
-worktree -> issue -> implement -> issue-gate -> commit
+worktree -> issue -> implement verified slice -> issue-gate -> commit
 ```
 
 Implications:
 
-- `git-commit-skill` is the closer of commit-stage work.
+- `git-commit-skill` is the closer for each verified save point.
 - If implementation drifted materially from the tracked issue or approved
   scope, repair traceability before commit execution.
+- If a feature was built through `workflow-build`, preserve the slice boundary
+  unless the slice is too small to review or revert on its own.
+
+## Branch And Worktree Check
+
+Before staging:
+
+1. Run `git status --short --branch`.
+2. Note the current branch and whether it tracks a remote.
+3. Confirm whether the working tree is mixed.
+4. If unrelated changes are present, stage only the explicitly in-scope paths.
+5. If the user is on a default branch and the project expects feature branches,
+   surface that before committing; do not create branches unless the user asked
+   for branch setup or the repo policy requires it.
+
+Prefer short-lived feature branches when branch setup is in scope. The commit
+discipline still applies when a team uses another branching model.
 
 ## Issue Gate Interaction
 
@@ -33,32 +73,154 @@ Implications:
 - If the gate returns `BLOCK`, stop commit output and report the blocker.
 - If the gate returns `refs_line`, use it in `Refs` unless the repository has a
   stricter traceability rule.
+- If no issue requirement is found and the change is low risk, use
+  `Refs: n/a`.
 
-## Split Guidance
+## Atomic Commit Boundary Rules
 
-- Use one commit per coherent task, fix, or delivery slice.
-- Split when one diff contains independently reviewable or revertible changes.
-- Keep tightly coupled code, tests, and docs together when they serve the same
-  task.
-- Avoid splitting so aggressively that traceability becomes fragmented.
+Each commit should be one coherent save point: independently understandable,
+reviewable, and revertible.
+
+Prefer one commit when all of these are true:
+
+- The diff serves one user or system intent.
+- Code, tests, docs, and generated files are tightly coupled to that intent.
+- Reverting the commit as a unit would make sense.
+- The staged diff is small enough to review without hiding unrelated behavior.
+
+Split into multiple commits when any of these are true:
+
+- Feature work and refactoring are mixed.
+- Formatting-only churn is mixed with behavior changes.
+- Dependency or build configuration changes are mixed with product logic.
+- Tests cover a separate behavior slice from later implementation changes.
+- Generated files can be regenerated from a prior source change and are large
+  enough to obscure the human-authored diff.
+- The diff contains independent UI, API, storage, or documentation intents.
+- A partial revert would be likely during review or rollback.
+
+Do not split when separation would produce commits that do not compile, do not
+pass relevant tests, or cannot be understood without a later commit.
+
+## Keep Concerns Separate
+
+Do not mix these concerns in one commit unless they are structurally
+inseparable:
+
+- feature behavior and refactoring
+- formatting-only churn and behavior changes
+- dependency or build configuration changes and product logic
+- generated files that obscure the human-authored source change
+- unrelated UI, API, storage, or documentation intents
+
+Small local cleanup can stay with a feature commit when it is directly needed
+for the feature and does not distract from review.
+
+## Size Your Changes
+
+Use size as a warning signal, not as the only split rule.
+
+Target about 100 changed lines per commit or PR. Changes over about 1000 lines
+should be split. Use the splitting strategies from `workflow-review` when a
+change is too large.
+
+```text
+~100 lines  -> Easy to review, easy to revert
+~300 lines  -> Acceptable for a single logical change
+~1000 lines -> Split into smaller changes
+```
+
+If a large commit remains intentionally unsplit, record the reason in the split
+decision rationale.
+
+## Splitting Strategies
+
+Use the smallest strategy that preserves working, reviewable commits:
+
+- Stack: submit one small change, then build the next change on top of it.
+- By file group: separate changes that need different reviewers or ownership.
+- Horizontal: land shared code, contracts, or stubs first, then consumers.
+- Vertical: split a feature into smaller full-stack slices.
+
+Large changes are acceptable when they are mostly complete file deletions,
+generated output, or automated refactors where the reviewer verifies the intent
+instead of every changed line.
 
 ## Staging Policy
 
-- Stage only approved, in-scope, AI-authored files by default.
+- Stage only approved, in-scope files by default.
+- Prefer explicit pathspecs over `git add -A`.
+- Use `git add -A` only when the entire working tree is confirmed in scope.
 - Ignore unrelated unstaged changes.
-- If a file mixes AI-authored changes with unrelated user edits, ask once
-  before staging that file.
+- If a file mixes in-scope changes with unrelated user edits, ask once before
+  staging that file.
 - Do not broaden scope silently just to make the diff look cleaner.
+
+When partial staging is needed, prefer non-interactive commands where possible.
+If interactive staging is the only safe path, stop and ask the user to confirm
+or perform it manually.
+
+## Pre-Commit Hygiene
+
+Before every executed commit:
+
+1. Inspect staged scope:
+   `git diff --cached`, `git diff --cached --stat`, and
+   `git diff --cached --name-status`.
+2. Check the staged diff for obvious secrets or credentials.
+3. Run the most relevant tests or checks for the staged change.
+4. If tests/checks are not run, record a real operational reason in `Tests`.
+5. Confirm generated files, lockfiles, snapshots, and schema outputs are
+   expected by the repository before including them.
+
+For documentation-only or metadata-only changes, `git diff --cached --check`
+is usually the minimum useful check.
+
+## Generated Files And Artifacts
+
+- Commit generated files only when the repository expects them, such as
+  lockfiles, generated schemas, checked-in fixtures, migrations, or approved
+  snapshots.
+- Do not commit build output, local environment files, editor state, cache
+  directories, or machine-specific artifacts.
+- If generated files are required but missing, stop and run the generation step
+  before committing when feasible.
 
 ## Execution Steps
 
-1. Select the in-scope files.
-2. Stage only those files.
-3. Write the final commit message to a file.
-4. Run `git commit -F <file>`.
-5. Report the commit hash, staged scope, and `Refs`.
+For each commit slice:
 
-## Worktree and Sandbox Notes
+1. Select the in-scope files for that slice.
+2. Confirm the slice is one logical change and satisfies the size guidance.
+3. Stage only those files.
+4. Run pre-commit hygiene.
+5. Write the final commit message using `commit-message-standard.md`.
+6. Run `git commit -F <file>`.
+7. Report commit hash, staged scope, tests, `Refs`, and remaining unstaged
+   scope.
+
+If multiple commits are required, repeat these steps one slice at a time and
+show the remaining unstaged scope after each commit.
+
+## Change Summary After Commit
+
+After any executed commit, provide a concise summary in the spirit of
+`git-workflow-and-versioning`:
+
+```text
+CHANGES COMMITTED:
+- <path>: <what changed>
+
+THINGS I DIDN'T TOUCH:
+- <path or area>: <why out of scope>
+
+POTENTIAL CONCERNS:
+- <risk, follow-up, or verification gap>
+```
+
+Omit empty sections, but always make verification gaps explicit.
+
+## Worktree And Sandbox Notes
 
 - In git worktree environments, `git add` may require elevated capability
   because Git writes metadata under `.git/worktrees/...`.
@@ -68,7 +230,13 @@ Implications:
 
 ## Things This Skill Should Not Do
 
-- It should not amend, rebase, or force-push unless the user explicitly asks.
+- It should not amend, rebase, squash, or force-push unless the user explicitly
+  asks.
 - It should not auto-stage unrelated files.
 - It should not fabricate `Refs` data when traceability is missing.
 - It should not convert wording-only requests into real commit execution.
+- It should not turn a mixed working tree into one broad commit just because
+  the user asked to "commit everything" unless the user confirms that scope.
+- It should not use the message template as a substitute for commit discipline:
+  the template explains the commit, but the workflow determines the commit
+  boundary.


### PR DESCRIPTION
## Summary

This PR revises `git-commit-skill` so its execution behavior follows save-point Git workflow discipline while keeping the existing structured commit message template.

## What Changed

- Reworked the skill around verified save points, atomic commit boundaries, size guidance, and concern separation.
- Expanded the execution policy with commit-early cadence, split strategies, staging rules, pre-commit hygiene, generated file handling, and post-commit summaries.
- Updated Codex metadata to describe save-point commit execution.

## Impact

Agents using `$git-commit-skill` should now prefer smaller, reviewable, revertible commit slices while still producing the required `Why / What / Impact / Tests / Refs` message format.

## Validation

- `git diff --cached --check`
- staged diff credential pattern scan: no matches
