### PR TITLE
[codex] Enforce commit section uniqueness

### DIFF
--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-skill
-description: v0.2.1 - Draft, split, and execute atomic scoped Git commits with issue traceability and structured Why/What/Impact/Tests/Refs bodies; use when preparing final commits, reviewing commit wording, or enforcing repo commit conventions.
+description: v0.2.2 - Draft, split, and execute atomic scoped Git commits with issue traceability and structured Why/What/Impact/Tests/Refs bodies; use when preparing final commits, reviewing commit wording, or enforcing repo commit conventions.
 ---
 
 # Git Commit Skill
@@ -61,6 +61,8 @@ Use this skill for prompts such as:
 - commit standard: Conventional Commits unless the repository explicitly uses
   another convention
 - commit body format: exact `Why / What / Impact / Tests / Refs`
+- section rule: each required body section appears exactly once; multiple
+  checks are bullets under the single `Tests` section
 - execution mode: full commit execution for normal commit-stage work
 - split policy: atomic save-point commits, based on
   `commit-execution-policy.md`
@@ -111,6 +113,9 @@ Use this skill for prompts such as:
 6. Build the body.
    - Use the exact section order:
      `Why`, `What`, `Impact`, `Tests`, `Refs`.
+   - Include each required section exactly once.
+   - If multiple commands or checks ran, list them as separate bullets under
+     the single `Tests` section.
    - Keep rationale and impact explicit.
    - Read `references/commit-message-standard.md` when you need the section
      quality bar or full examples.
@@ -164,6 +169,10 @@ Use this skill for prompts such as:
   confirmation.
 - Do not continue to commit execution when `issue-gate-skill` returns `BLOCK`.
 - Do not write single-line commit messages.
+- Do not duplicate body sections; `Why`, `What`, `Impact`, `Tests`, and `Refs`
+  must each appear exactly once.
+- Do not create a second `Tests` section for another command; add another
+  bullet under the existing `Tests` section.
 - Do not squash independent save points into one broad commit merely for speed.
 - Do not accumulate verified increments into a giant end-of-task commit.
 - Do not split tightly coupled code, tests, and docs when they form one

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Commit"
-  short_description: "v0.2.1 - Execute save-point Git commits"
+  short_description: "v0.2.2 - Execute save-point Git commits"
   default_prompt: "Use $git-commit-skill to review the current diff, apply save-point commit discipline, split by size and concern, confirm traceability, and execute commits with the required Why/What/Impact/Tests/Refs structure."

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
@@ -38,6 +38,17 @@ Refs:
 
 This structure is mandatory. Do not add extra sections.
 
+Each required body section must appear exactly once:
+
+- one `Why:`
+- one `What:`
+- one `Impact:`
+- one `Tests:`
+- one `Refs:`
+
+When more than one validation command ran, keep a single `Tests:` section and
+list each command as its own bullet. Never create a second `Tests:` heading.
+
 ## Subject Rules
 
 Structured subject output is required.
@@ -176,6 +187,9 @@ Refs:
 ### Tests
 
 - State what actually ran.
+- Use exactly one `Tests:` section.
+- Put every test, compile command, lint command, manual check, or skipped-test
+  reason as a bullet under that single section.
 - If tests did not run, use one of these forms:
   - `not run (manual run pending)`
   - `not run (docs-only change)`
@@ -195,5 +209,9 @@ Refs:
 ## Format Rules
 
 - Follow the exact section order shown above.
+- Include each required section exactly once.
 - Do not add extra sections.
+- Do not repeat a section heading to list another item.
+- Combine multiple test commands under one `Tests:` heading as separate
+  bullets.
 - Single-line commit messages are not allowed.


### PR DESCRIPTION
## Summary

This PR strengthens `git-commit-skill` so generated commit messages keep the required body sections unique.

## What Changed

- Bumped `git-commit-skill` to `v0.2.2`.
- Added a fixed rule that `Why`, `What`, `Impact`, `Tests`, and `Refs` each appear exactly once.
- Clarified that multiple validation commands must be bullets under one `Tests` section, not separate `Tests` headings.
- Synced the Codex metadata version.

## Impact

Agents using `$git-commit-skill` should avoid duplicate body headings and keep multi-command validation output inside a single `Tests` section.

## Validation

- `git diff --cached --check`
- staged diff credential pattern scan: no matches
