### PR TITLE
[codex] Harden development skill pack workflows

### DIFF
--- a/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan-record/SKILL.md
+++ b/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan-record/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-plan-record
-description: v0.1.1 - Records an already completed workflow-plan into a compact task-run plan.yaml artifact. Use after workflow-plan when a full human-readable implementation plan exists, when workflow-sketch or workflow-build needs a .agent-runs handoff, or when an approved plan revision must update an existing run.
+description: v0.1.2 - Records an already completed implementation plan into a compact task-run plan.yaml artifact. Use when a full human-readable implementation plan exists, when workflow-sketch or workflow-build needs a .agent-runs handoff, or when an approved plan revision with success targets must update an existing run.
 ---
 
 # Workflow Plan Record
@@ -17,7 +17,8 @@ issue handoff. Do not let YAML formatting drive the planning work.
 
 The artifact exists so later `workflow-sketch`, `workflow-build`, or another
 session can recover the approved goal, slice order, verification expectations,
-and issue references without replaying the whole conversation.
+success targets, quality gates, and issue references without replaying the
+whole conversation.
 
 ## When to Use
 
@@ -40,8 +41,8 @@ Before touching `.agent-runs/`, identify the final source plan to record:
 - Use the completed `workflow-plan` output from the current conversation or a
   provided plan document.
 - Confirm the source plan includes goal, scope, ordered tasks or slices,
-  verification, checkpoints or dependencies, risks or open questions when
-  relevant, and issue handoff.
+  success targets or quality gates, verification, checkpoints or dependencies,
+  risks or open questions when relevant, and issue handoff.
 - If there is no complete source plan, stop and ask for `workflow-plan` first.
 
 **Do NOT infer a plan from code diffs or rough conversation fragments.** This
@@ -91,9 +92,11 @@ Use `references/plan-record-template.yaml` and keep only durable handoff data:
 - `goal`
 - `scope.in`
 - `scope.out`
+- `success_targets`
 - `slices[].id`
 - `slices[].outcome`
 - `slices[].rationale`
+- `slices[].quality_target`
 - `slices[].target_areas`
 - `slices[].depends_on`
 - `slices[].verify`
@@ -110,7 +113,9 @@ Put only plan-level handoff in `plan.yaml`.
 Belongs in `plan.yaml`:
 
 - task goal and scope boundaries
+- final success targets and quality gates
 - slice order and dependency summary
+- slice-level quality targets
 - target areas, not exhaustive file diffs
 - verification commands or checks
 - issue refs
@@ -135,8 +140,9 @@ Before reporting success:
 
 - Confirm `plan.yaml` reflects the final source plan, not an earlier draft.
 - Confirm every slice maps to a source task, phase, or checkpoint.
-- Confirm each slice has a rationale, target areas, dependencies, and
-  verification.
+- Confirm success targets and slice-level quality targets were preserved.
+- Confirm each slice has a rationale, target areas, dependencies,
+  verification, and quality target.
 - Confirm `.agent-runs/` is ignored and not staged.
 - Confirm no business code was modified.
 
@@ -151,10 +157,19 @@ scope:
     - "<included area>"
   out:
     - "<excluded area>"
+success_targets:
+  - id: "<target-id>"
+    outcome: "<final user or system outcome>"
+    quality_bar:
+      - "<observable quality standard>"
+    evidence_required:
+      - "<test, log, trace, screenshot, metric, or manual check>"
+    failure_policy: "block | warn | follow-up"
 slices:
   - id: "<slice-id>"
     outcome: "<verifiable outcome>"
     rationale: "<why this slice is ordered here>"
+    quality_target: "<quality outcome this slice must reach>"
     target_areas:
       - "<module or subsystem>"
     depends_on: []
@@ -181,9 +196,13 @@ probably belongs in the human-readable plan or the slice sketch instead.
   artifact, not to `plan.yaml`.
 - If issue references are absent from the source plan, use `n/a` only when the
   plan explicitly says issue handoff is unnecessary.
+- If success targets are absent from the source plan, mark the source plan as
+  incomplete instead of inventing quality gates during recording.
 - If a slice is too broad to record with a specific outcome and verification,
   mark the source plan as needing refinement instead of recording a vague
   slice.
+- If a slice has no quality target, preserve the gap in blockers instead of
+  silently recording verification commands as the quality target.
 
 ## Recording Examples
 
@@ -221,15 +240,18 @@ must follow the completed plan.
 | "A new run_id is cleaner for every update." | Reuse the same run for the same implementation goal to avoid fragmented task history. |
 | "The plan is obvious from the branch name." | Branch names are context hints, not approved plan sources. |
 | "This is only temporary, so staging .agent-runs is fine." | Task-run artifacts are local workbench state and should stay out of commits. |
+| "Verification commands are enough quality data." | Commands are evidence; record the outcome and quality bar they are meant to prove. |
 
 ## Red Flags
 
 - `plan.yaml` is created before a complete human-readable plan exists.
 - The artifact includes implementation details that belong in `workflow-sketch`.
 - The artifact changes scope or task order without updating the source plan.
+- The artifact drops success targets or quality gates from the source plan.
 - A new run is created for a refinement of the same goal.
 - `.agent-runs/` appears in staged files.
 - Slices are named by file edits instead of verifiable outcomes.
+- A slice has verification commands but no quality target.
 - `verify` is missing or says only "manual check" without a concrete action.
 - `issue_refs` invents an issue or drops issue handoff from the source plan.
 - The output report presents the YAML record as the implementation plan.
@@ -240,7 +262,9 @@ must follow the completed plan.
 - [ ] `.agent-runs/<run-id>/plan.yaml` exists.
 - [ ] The artifact reflects the final plan, including task order and
       verification.
+- [ ] Success targets and quality gates were recorded from the source plan.
 - [ ] Each slice has a rationale.
+- [ ] Each slice has a quality target.
 - [ ] `.agent-runs/` is ignored by git.
 - [ ] No business code was modified.
 - [ ] `git status --short` does not show `.agent-runs/` as staged or
@@ -263,6 +287,9 @@ must follow the completed plan.
 
 ## Recorded Slices
 - <slice-id>: <outcome>
+
+## Success Targets
+- <target-id>: <outcome>
 
 ## Verification
 - source_plan_checked:

--- a/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan-record/agents/openai.yaml
+++ b/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan-record/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Workflow Plan Record"
-  short_description: "v0.1.1 - Record a completed plan into .agent-runs plan.yaml"
-  default_prompt: "Use $workflow-plan-record only after a full workflow-plan exists: record the approved plan into .agent-runs/<run-id>/plan.yaml, preserve slice order and verification, and do not perform new planning or code changes."
+  short_description: "v0.1.2 - Record a completed plan into .agent-runs plan.yaml"
+  default_prompt: "Use $workflow-plan-record only after a full implementation plan exists: record the approved plan into .agent-runs/<run-id>/plan.yaml, preserve success targets, quality gates, slice order, and verification, and do not perform new planning or code changes."

--- a/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan-record/references/plan-record-template.yaml
+++ b/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan-record/references/plan-record-template.yaml
@@ -6,10 +6,19 @@ scope:
     - "<included area>"
   out:
     - "<excluded area>"
+success_targets:
+  - id: "<target-id>"
+    outcome: "<final user or system outcome>"
+    quality_bar:
+      - "<observable quality standard>"
+    evidence_required:
+      - "<test, log, trace, screenshot, metric, or manual check>"
+    failure_policy: "block | warn | follow-up"
 slices:
   - id: "<slice-id>"
     outcome: "<verifiable outcome>"
     rationale: "<why this slice is ordered here>"
+    quality_target: "<quality outcome this slice must reach>"
     target_areas:
       - "<module or subsystem>"
     depends_on: []

--- a/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan/SKILL.md
+++ b/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-plan
-description: v0.1.5 - Breaks work into ordered, verifiable tasks with issue handoff. Use when you have a spec or clear requirements and need to break work into implementable tasks, estimate scope, identify parallel work, prepare issue-backed acceptance tracking, or produce a full human-readable implementation plan before workflow-plan-record.
+description: v0.1.6 - Breaks work into ordered, verifiable tasks with final success targets, quality gates, and issue handoff. Use when you have a spec or clear requirements and need to break work into implementable tasks, estimate scope, identify quality outcomes, prepare issue-backed acceptance tracking, or produce a full human-readable implementation plan.
 ---
 
 # Planning and Task Breakdown
@@ -12,9 +12,10 @@ Good task breakdown is the difference between an agent that completes work
 reliably and one that produces a tangled mess. Every task should be small
 enough to implement, test, and verify in a single focused session.
 
-Plan quality comes before artifact formatting. Produce the complete
-human-readable implementation plan here. If a recorded task-run handoff is
-needed afterward, use `workflow-plan-record` after this skill finishes.
+Plan quality comes before execution. Produce the complete human-readable
+implementation plan here: what will be built, what final outcome must be true,
+what quality bar must be met, and how each slice can prove progress toward
+that outcome.
 
 ## When to Use
 
@@ -38,7 +39,7 @@ Before writing any code, operate in read-only mode:
 - Note risks and unknowns
 
 **Do NOT write code during planning.** The output is a human-readable plan
-document, not implementation and not a task-run artifact.
+document, not implementation.
 
 ### Step 2: Identify the Dependency Graph
 
@@ -97,6 +98,9 @@ Each task follows this structure:
 - [ ] [Specific, testable condition]
 - [ ] [Specific, testable condition]
 
+**Quality target:**
+- [ ] [User/system quality outcome this task must reach, not just code completion]
+
 **Verification:**
 - [ ] Tests pass: `npm test -- --grep "feature-name"`
 - [ ] Build succeeds: `npm run build`
@@ -118,7 +122,33 @@ Each task follows this structure:
 - issue_rationale: [why this should become a separate issue, be grouped, or stay parent-only]
 ```
 
-### Step 4.5: Prepare Issue Handoff
+### Step 4.5: Define Success Targets and Quality Gates
+
+Before finalizing the task list, define what "done well" means for the feature
+or change. This is broader than code compiling or unit tests passing.
+
+Add a `Success Targets` section with:
+
+- final user or system outcome
+- behavior quality that must be true
+- evidence required to prove the outcome
+- failure policy when the target is not met
+
+Use this shape:
+
+```markdown
+## Success Targets
+
+| Target | Quality bar | Evidence required | Failure policy |
+|--------|-------------|-------------------|----------------|
+| [Outcome name] | [What good looks like] | [Tests, logs, manual checks, traces, screenshots, metrics] | block | warn | follow-up |
+```
+
+Quality gates should be specific enough that later testing can determine
+whether the work reached the intended standard. Avoid vague targets like
+"works well" or "good UX" without observable evidence.
+
+### Step 4.6: Prepare Issue Handoff
 
 When the plan may be passed to `issue-gate-skill`, add an `Issue Handoff`
 section after the task list. This is not issue creation; it is a routing map
@@ -201,6 +231,11 @@ If a task is L or larger, it should be broken into smaller tasks. An agent perfo
 - [Key decision 1 and rationale]
 - [Key decision 2 and rationale]
 
+## Success Targets
+| Target | Quality bar | Evidence required | Failure policy |
+|--------|-------------|-------------------|----------------|
+| [Outcome name] | [What good looks like] | [Tests, logs, manual checks, traces, screenshots, metrics] | block |
+
 ## Task List
 
 ### Phase 1: Foundation
@@ -258,17 +293,20 @@ When multiple agents or sessions are available:
 | "The tasks are obvious" | Write them down anyway. Explicit tasks surface hidden dependencies and forgotten edge cases. |
 | "Planning is overhead" | Planning is the task. Implementation without a plan is just typing. |
 | "I can hold it all in my head" | Context windows are finite. Written plans survive session boundaries and compaction. |
-| "The plan artifact can be the plan." | `workflow-plan` produces the full human-readable plan. `workflow-plan-record` can record it afterward. |
-| "I'll handle the run boundary while planning." | Run boundaries and task-run artifacts are recording concerns. Finish planning first. |
+| "Passing tests is the success target." | Tests are evidence. The plan still needs to state the user or system quality outcome those tests prove. |
+| "Quality can be judged at the end." | Late quality judgment lets implementation drift. Define the quality bar before slicing. |
 
 ## Red Flags
 
 - Starting implementation without a written task list
 - Tasks that say "implement the feature" without acceptance criteria
+- Acceptance criteria that only describe code completion, not the target
+  outcome or quality bar
+- No success targets for the final user or system outcome
 - No verification steps in the plan
 - No issue handoff guidance when the plan will be used for tracked work
-- Creating or updating task-run artifacts before the plan is complete
-- Letting artifact fields replace architecture decisions, risks, or checkpoints
+- Letting output formats replace architecture decisions, risks, quality gates,
+  or checkpoints
 - All tasks are XL-sized
 - No checkpoints between tasks
 - Dependency order isn't considered
@@ -278,6 +316,7 @@ When multiple agents or sessions are available:
 Before starting implementation, confirm:
 
 - [ ] Every task has acceptance criteria
+- [ ] The plan defines final success targets and quality gates
 - [ ] Every task has a verification step
 - [ ] Every task has issue handoff guidance or an explicit reason issue
       handoff is unnecessary
@@ -285,5 +324,3 @@ Before starting implementation, confirm:
 - [ ] No task touches more than ~5 files
 - [ ] Checkpoints exist between major phases
 - [ ] The human has reviewed and approved the plan
-- [ ] `workflow-plan-record` is identified as the follow-up when a task-run
-      artifact is needed

--- a/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan/agents/openai.yaml
+++ b/agent-specs/engineering/skills/development-skill-pack/workflow-lifecycle/workflow-plan/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Workflow Plan"
-  short_description: "v0.1.5 - Break a spec into a full human-readable plan"
-  default_prompt: "Use $workflow-plan to write the full human-readable implementation plan with architecture decisions, tasks, risks, checkpoints, and issue handoff; use workflow-plan-record afterward only if a recorded handoff is needed."
+  short_description: "v0.1.6 - Break a spec into a full human-readable plan"
+  default_prompt: "Use $workflow-plan to write the full human-readable implementation plan with architecture decisions, success targets, quality gates, ordered tasks, risks, checkpoints, and issue handoff."


### PR DESCRIPTION
## Summary

This PR updates the development skill pack with stronger workflow guidance and new reusable skills.

Highlights:

- Add prompt architecture author/review skills.
- Add semantic naming review skill.
- Harden workflow-build around skeleton-first implementation gates and helper audits.
- Split plan recording into `workflow-plan-record` so `workflow-plan` stays focused on human-readable planning.
- Add task-run `workflow-sketch` and `workflow-check` artifacts for pre-build implementation contracts and post-build adherence checks.
- Add success targets and quality gates to workflow-plan, while keeping task-run recording isolated in workflow-plan-record.
- Tighten workflow-simplify and skill routing documentation around the updated lifecycle.

## Why

Recent workflow iterations showed that agents can appear compliant while skipping the actual thinking, sketching, testing, or verification phase. The skill pack now makes those lifecycle boundaries explicit and gives each phase a separate contract.

## Impact

- No runtime code changes.
- Skill users get clearer phase boundaries: plan, record, sketch, build, test, check, review.
- Plans now define final quality targets before later phases gather evidence.
- Task-run artifacts remain separate from human-readable planning to avoid polluting the planning step.

## Validation

- `git diff --check upstream/main...HEAD`
- Secret scan over the PR diff: no matches.
- Per-commit skill metadata/YAML/JSON checks were run while landing the workflow skill updates.

Refs: https://github.com/JeanphiloGong/Agents-spec/issues/58
