### PR TITLE
[codex] Add HTML report workflow and tighten commit messaging

### DIFF
--- a/agent-specs/engineering/skills/README.md
+++ b/agent-specs/engineering/skills/README.md
@@ -11,7 +11,7 @@ the package README files explain when to use each group.
 | [`development-skill-pack`](development-skill-pack/README.md) | General development lifecycle skills imported as a curated local pack. |
 | [`implementation-guides`](implementation-guides/README.md) | Skills for learning, reference implementations, and human-led landing from drafts. |
 | [`delivery-workflow`](delivery-workflow/README.md) | Skills for issue traceability, commits, PR/MR publishing, reviews, and releases. |
-| [`engineering-communication`](engineering-communication/README.md) | Skills for engineering diagrams and business-readable work summaries. |
+| [`engineering-communication`](engineering-communication/README.md) | Skills for engineering diagrams, HTML reports, and business-readable work summaries. |
 
 ## Usage
 

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-skill
-description: v0.2.3 - Draft, split, and execute atomic scoped Git commits with issue traceability and structured Why/What/Impact/Tests/Refs bodies. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
+description: v0.2.4 - Draft, split, and execute atomic scoped Git commits with verified traceability and concise, concrete Why/What/Impact/Tests/Refs bodies. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
 ---
 
 # Git Commit Skill
@@ -10,7 +10,11 @@ description: v0.2.3 - Draft, split, and execute atomic scoped Git commits with i
 Prepare commit-stage work as a verified, traceable save point. This skill
 decides whether the current diff should be committed, split, or only drafted;
 then it stages only approved in-scope files and writes a repository-quality
-commit message with `Why / What / Impact / Tests / Refs`.
+commit message with concrete `Why / What / Impact / Tests / Refs` evidence.
+The sections must tell one causal story without replacing observable changes
+with intent summaries such as "clarify responsibility" or "improve
+consistency." Each supporting detail appears once, in the section that owns
+it; repeat the core behavior only when needed to connect the causal chain.
 
 Use the existing commit-message and execution references for details. The
 always-loaded behavior is: inspect first, preserve unrelated changes, verify
@@ -53,6 +57,10 @@ issue mapping, and use review or CI skills for review/CI failures.
 - commit body format: exact `Why / What / Impact / Tests / Refs`
 - section rule: each required body section appears exactly once; multiple
   checks are bullets under the single `Tests` section
+- evidence rule: derive the subject and every section from the user request,
+  issue, staged diff, or verification results
+- density rule: use one bullet with one sentence per section by default; add a
+  second bullet only for a separate fact required to understand the commit
 - execution mode: full commit execution for normal commit-stage work
 - split policy: atomic save-point commits, based on
   `commit-execution-policy.md`
@@ -90,20 +98,37 @@ issue mapping, and use review or CI skills for review/CI failures.
      reviewable and revertible save point.
    - Use stack, file-group, horizontal, or vertical splitting when the diff is
      too large or mixed by intent.
-5. Write the subject and body.
+5. Build the evidence card before writing prose.
+   - Read `references/commit-message-standard.md`.
+   - Record the concrete primary action and object from the staged diff.
+   - Record the previous behavior or pressure, the resulting behavior or
+     structure, the material impact boundary, the checks that actually ran,
+     and verified references.
+   - Select the smallest useful fact for each message section; do not render
+     every fact collected in the evidence card.
+6. Write and challenge the subject and body.
    - Choose the commit type and optional scope.
-   - Keep the subject imperative and one sentence.
-   - Use the exact body section order: `Why`, `What`, `Impact`, `Tests`,
-     `Refs`.
-   - Put multiple commands or checks as bullets under the single `Tests`
-     section.
-6. Execute the selected path.
+   - Write the shortest natural subject that still names the concrete action
+     and recognizable object.
+   - If the subject only states a goal or quality, replace it with the actual
+     rename, extraction, move, removal, behavior correction, or other staged
+     action.
+   - Keep long identifiers in `What` only when they materially improve
+     recognition; do not coin compressed domain terms to fit them in the
+     subject.
+   - Render the exact section order: `Why`, `What`, `Impact`, `Tests`, `Refs`.
+   - Give each section one job: reason, change, effect, proof, or reference.
+     Do not repeat tests, call-site counts, assertions, or state tables across
+     sections.
+   - Make the sections read as one chain: previous problem -> implemented
+     change -> observable result or preserved boundary -> proof -> reference.
+7. Execute the selected path.
    - For `draft_only` or `split_only`, return the draft or split plan without
      staging.
    - For `execute`, stage only approved in-scope files for one slice, run the
      required hygiene checks, write the final message to a file, and run
      `git commit -F <file>`.
-7. Report the save point.
+8. Report the save point.
    - Include commit hash when committed.
    - Include staged scope, traceability status, tests status, and any remaining
      unstaged scope.
@@ -118,6 +143,17 @@ issue mapping, and use review or CI skills for review/CI failures.
   blocker.
 - If traceability is optional and no canonical issue applies, use
   `Refs: - n/a`; do not invent an issue.
+- If the primary action or object cannot be named from the staged diff, inspect
+  again instead of substituting an intent phrase.
+- If a precise identifier makes the subject long or hard to read, use the
+  established project noun in the subject and leave the identifier to `What`
+  or the diff.
+- If a test fact appears in `Why`, `What`, or `Impact`, move it to `Tests`
+  unless the test itself is the primary change.
+- If call-site counts or individual assertions do not change the reader's
+  understanding, omit them.
+- If the reason or impact cannot be supported, state the narrow verified
+  boundary; do not invent a benefit or failure mode.
 - If the diff is one logical change around 300 changed lines, one commit is
   acceptable when the verification and rollback boundary are still clear.
 - If the diff is around 1000 changed lines or mixes unrelated concerns, split
@@ -132,15 +168,34 @@ issue mapping, and use review or CI skills for review/CI failures.
 | "All the files are already dirty, so staging everything is fastest." | Dirty is not the same as in scope. Stage only approved files for the current save point. |
 | "The issue is obvious, so I can write a plausible Refs line." | Traceability must come from `issue-gate-skill`, repository evidence, or `n/a`; never invent issue links. |
 | "This is just docs, so a one-line commit is fine." | Repository history still needs Why, What, Impact, Tests, and Refs. |
+| "Clarify responsibility summarizes a rename." | Intent is not an observable change. Name the renamed object, and use the real identifier when it improves recognition. |
+| "The body can report that the change improves consistency." | Broad quality claims hide behavior. State the previous and resulting behavior or the exact boundary that stayed unchanged. |
+| "More identifiers and state values make the message more concrete." | Detail is useful only in its owning section. Prefer the shortest established project terms that preserve meaning. |
+| "Every discovered fact should appear in the body." | The evidence card is an input filter, not an output checklist. Keep only what a future reader needs. |
 | "The diff is large but it is easier to review as one commit." | Large mixed commits hide intent and rollback boundaries; split unless the change is one inseparable unit. |
-| "I can add another Tests section for the second command." | The body has one `Tests` section with multiple bullets. |
+| "Tests are already in the execution report." | The repository requires durable verification evidence in the single Tests section. |
+| "I can add another Tests section for the second command." | The body has one Tests section with multiple bullets. |
 
 ## Red Flags
 
 - `git add .` or broad staging appears while unrelated dirty files exist.
 - The commit body lacks one of `Why`, `What`, `Impact`, `Tests`, or `Refs`.
 - The same required section appears more than once.
-- The subject explains cause and effect instead of the action.
+- The subject names an intention or quality such as "明确职责", "优化逻辑",
+  "提升一致性", or "clarify behavior" without naming the staged action.
+- The subject coins a dense noun phrase such as "完成态缓存恢复函数" instead
+  of using an established project term or a natural verb phrase.
+- The subject cannot answer "what did this commit do?" without reading the
+  body.
+- `Why` restates the subject instead of naming the previous problem or trigger.
+- `Why` explains why a test was added or speculates about a future regression.
+- `What` avoids the actual behavior, structure, identifier, or state value.
+- `What` reports call-site counts or test assertions that belong in the diff or
+  `Tests`.
+- `Impact` claims a generic benefit instead of an observable result or
+  preserved boundary.
+- `Impact` repeats a state-by-state result table for a behavior-preserving
+  refactor.
 - `Refs` names an issue that was not verified or supplied.
 - Independent feature, refactor, formatting, dependency, or generated-file
   changes are bundled together for speed.
@@ -152,10 +207,18 @@ issue mapping, and use review or CI skills for review/CI failures.
 - [ ] Branch, worktree, and diff were inspected before staging.
 - [ ] Staged files are limited to the approved in-scope slice.
 - [ ] Split decision is recorded with size and concern rationale.
-- [ ] Traceability is verified through `issue-gate-skill`, repository evidence,
-      explicit user input, or `Refs: - n/a`.
+- [ ] The subject names the primary staged action and object rather than its
+      intended quality.
+- [ ] The subject uses natural project language and contains no coined noun
+      stack.
+- [ ] `Why -> What -> Impact` forms a factual cause-and-result chain.
 - [ ] Commit message has exactly one `Why`, `What`, `Impact`, `Tests`, and
       `Refs` section in that order.
+- [ ] Every claim is grounded in the request, issue, staged diff, or tests.
+- [ ] Each supporting detail appears in only one owning section, with one
+      bullet per section unless a second independent fact is necessary.
+- [ ] Traceability is verified through `issue-gate-skill`, repository evidence,
+      explicit user input, or `Refs: - n/a`.
 - [ ] Required pre-commit hygiene checks from
       `references/commit-execution-policy.md` were run or explicitly blocked.
 - [ ] Execution result reports commit hash, test status, and remaining
@@ -212,8 +275,16 @@ issue mapping, and use review or CI skills for review/CI failures.
 - Do not require an AI session identifier unless the repository explicitly
   requires it.
 - Do not amend, rebase, or force-push unless the user explicitly asks.
+- Do not use an intention, benefit, or quality claim as a substitute for the
+  concrete action and object in the subject.
+- Do not treat specificity as permission to pack identifiers, state values,
+  call-site counts, and assertions into every section.
+- Do not invent Chinese domain labels by stacking translated technical nouns;
+  reuse established repository terms or leave code values unchanged.
 - Do not turn commit subjects into cause-and-effect sentences; keep reasons in
-  `Why` and `Impact`.
+  `Why` and consequences in `Impact`.
+- Do not invent a story unsupported by the staged change and its available
+  evidence.
 - If worktree or sandbox constraints block `git add` or `git commit`, surface
   the exact blocker and continue only after the required capability is
   available.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Commit"
-  short_description: "v0.2.3 - Execute traceable save-point Git commits"
-  default_prompt: "Use $git-commit-skill to review the current diff, apply save-point commit discipline, split by size and concern, confirm traceability, and execute commits with the required Why/What/Impact/Tests/Refs structure."
+  short_description: "v0.2.4 - Execute concise, traceable Git commits"
+  default_prompt: "Use $git-commit-skill to inspect the staged evidence, split by size and concern, verify traceability, and execute each save-point commit with the shortest concrete subject plus one focused bullet in each required Why/What/Impact/Tests/Refs section."

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
@@ -4,16 +4,74 @@ Use this reference when writing or reviewing the actual commit message.
 
 ## Table of Contents
 
-- [Commit Message Standard](#commit-message-standard)
+- [Task Model](#task-model)
+- [Evidence Card](#evidence-card)
+- [Commit Message Format](#commit-message-format)
 - [Subject Rules](#subject-rules)
-- [Type Hints](#type-hints)
-- [Common Types](#common-types)
-- [Selection Rules](#selection-rules)
-- [Full Examples](#full-examples)
+- [Information Ownership](#information-ownership)
 - [Body Quality Bar](#body-quality-bar)
-- [Format Rules](#format-rules)
+- [Type Selection](#type-selection)
+- [Full Examples](#full-examples)
+- [Anti-Patterns](#anti-patterns)
+- [Verification](#verification)
 
-## Commit Message Standard
+## Task Model
+
+A commit message is the shortest complete account of one staged change for a
+future engineer reading history. It must identify the observable change,
+explain the reason, record its boundary and proof, and preserve traceability.
+
+The task is not to praise the change, summarize the author's intention, or
+turn the diff into polished prose. Phrases such as "clarify responsibility,"
+"improve consistency," and "strengthen handling" describe desired qualities;
+they do not tell the reader what the commit did.
+
+The five required sections still form a story:
+
+```text
+previous problem -> concrete change -> observable result -> proof -> reference
+       Why              What              Impact       Tests      Refs
+```
+
+Keep the structure visible. Improve readability by selecting one useful fact
+for each field, not by removing fields or rendering the entire evidence card.
+
+## Evidence Card
+
+Build this private evidence card before drafting the message:
+
+```text
+primary_action: <rename | extract | move | remove | add | prevent | ...>
+primary_object: <behavior, symbol, document, contract, or state transition>
+before: <specific previous behavior, ambiguity, failure, or request>
+after: <specific resulting behavior or structure>
+impact_boundary: <observable effect or behavior explicitly preserved>
+tests: <commands or checks that actually ran, with results>
+refs: <verified issue/spec/incident/PR, or n/a when allowed>
+```
+
+Use these sources in this order:
+
+1. The staged diff is authoritative for the action, object, and contained
+   behavior.
+2. The issue or user request supplies the trigger and intended outcome.
+3. Tests establish verified behavior; they do not justify claims they do not
+   exercise.
+4. Repository conventions determine type, scope, and reference syntax.
+
+Do not draft the subject until `primary_action` and `primary_object` are both
+known. Inspect the diff again when either field would otherwise contain an
+intent word such as "clarify," "optimize," or "improve."
+
+After gathering evidence, select only what a future reader needs. Evidence can
+remain unrendered when the diff already carries it and omitting it does not
+make the message ambiguous.
+
+Use real identifiers and state values only when they improve recognition. Long
+identifiers belong in `What` or may stay in the diff when a familiar project
+noun is sufficient. Never invent a symbol name that is not in the staged diff.
+
+## Commit Message Format
 
 Use this exact structure:
 
@@ -36,162 +94,120 @@ Refs:
 - ...
 ```
 
-This structure is mandatory. Do not add extra sections.
-
-Each required body section must appear exactly once:
-
-- one `Why:`
-- one `What:`
-- one `Impact:`
-- one `Tests:`
-- one `Refs:`
-
-When more than one validation command ran, keep a single `Tests:` section and
-list each command as its own bullet. Never create a second `Tests:` heading.
+This structure is mandatory. Do not add, omit, rename, or duplicate sections.
+When several checks ran, list them as separate bullets under the single
+`Tests` section. Use one bullet with one sentence in every section by default.
+Add another bullet only for a separate fact required to understand the commit.
 
 ## Subject Rules
 
-Structured subject output is required.
+Write the subject from `primary_action + primary_object`.
 
 - Use a concise, imperative, present-tense subject.
-- Focus on what changed and where.
-- Keep reasons and consequences out of the subject; put them in `Why` or
+- Name the staged action or corrected behavior, not its intended quality.
+- Add a short condition only when it is needed to distinguish the behavior.
+- Prefer the shortest established project noun that identifies the object.
+- Put a renamed identifier in the subject only when it is short and more
+  recognizable than the project noun.
+- Keep reasons and consequences out of the subject; put them in `Why` and
   `Impact`.
+- Follow the user's language or the repository's recent commit language. Code
+  identifiers may remain in their original language.
+- Keep the subject under 72 characters when practical; shorten context before
+  removing the action or object.
 
-Subject template:
+Choose verbs that expose the actual change:
 
-```text
-<type>(optional-scope): <one-sentence subject>
-```
+| Type | Prefer concrete verbs | Do not substitute |
+|---|---|---|
+| `feat` | add, expose, support, enable | improve capability |
+| `bugfix` | prevent, reject, preserve, return, mark | fix consistency |
+| `hotfix` | restore, stop, disable, roll back | stabilize service |
+| `refactor` | rename, extract, move, inline, split, remove | clarify responsibility |
+| `docs` | document, correct, add, remove | improve documentation |
+| `test` | cover, reproduce, verify | strengthen tests |
+| `chore` | bump, remove, regenerate, configure | update maintenance |
 
-Subject checklist:
+Apply these reader checks:
 
-- One sentence with an imperative verb plus object and scope.
-- No cause or impact clauses such as `because`, `so that`, `以便`, `由于`, or
-  `因此`.
-- Prefer user-facing capability or document area over implementation detail.
-- Keep under 50 characters when possible; trim adjectives first.
-- Avoid vague verbs such as `update stuff` or `misc`.
+1. After removing the scope, can the reader answer "what did this commit do?"
+2. Does the subject contain only the detail needed in `git log --oneline`?
+3. Does every important noun use established project language rather than a
+   newly translated or compressed domain label?
+4. Would replacing the verb with "improve" preserve the same meaning? If yes,
+   the subject is still too abstract.
 
-## Type Hints
+## Information Ownership
 
-- `feat`: add / enable / introduce / support
-- `bugfix`: fix / handle / prevent
-- `hotfix`: restore / mitigate / stop
-- `docs`: clarify / add / update
-- `refactor`: refactor / simplify / reorganize
-- `test`: add / expand / cover
-- `chore`: update / bump / clean
+Assign each fact to one location before writing:
 
-## Common Types
+| Location | Owns | Does not own |
+|---|---|---|
+| Subject | shortest recognizable action and object | identifiers, reasons, tests, impact details |
+| `Why` | one previous problem or trigger | test motivation, future speculation, solution details |
+| `What` | one resulting code, behavior, or document change | call-site counts, assertion lists, impact claims |
+| `Impact` | one observable effect or preserved boundary | repeated state tables, implementation details |
+| `Tests` | checks that ran and their result | why the production change was needed |
+| `Refs` | verified traceability | extra explanation |
 
-- `feat`: new user-facing feature
-- `bugfix`: non-urgent bug fix on normal release cadence
-- `hotfix`: urgent production-impacting fix
-- `docs`: documentation change
-- `refactor`: code reorganization without behavior change
-- `test`: test addition or update
-- `chore`: tooling or maintenance work
+State each supporting detail once. Repeat the core behavior only when needed to
+connect `Why`, `What`, and `Impact`; do not repeat call-site counts, full state
+tables, function ownership, or test assertions merely because they are true.
 
-## Selection Rules
+Write natural project language:
 
-- Use `bugfix` for defects that can ship in the next normal release.
-- Use `hotfix` only for production-impacting issues that require expedited
-  release handling.
-- If uncertain, default to `bugfix` and explain urgency in `Impact`.
-
-## Full Examples
-
-```text
-feat(search): add date range filters
-
-Why:
-- Users need to narrow results by date and status.
-
-What:
-- Add filter params to the query builder.
-- Extend the search handler to accept the new filters.
-
-Impact:
-- More precise search results; no breaking changes.
-
-Tests:
-- unit: search_filter_spec
-
-Refs:
-- ISSUE-1423
-```
-
-```text
-bugfix(auth): handle refresh token expiry
-
-Why:
-- Sessions were failing silently after refresh token expiry.
-
-What:
-- Add explicit refresh error handling in auth middleware.
-- Surface a clear user-facing error message.
-
-Impact:
-- Fewer silent auth drop-offs; no API contract changes.
-
-Tests:
-- unit: auth_refresh_spec
-
-Refs:
-- AUTH-221
-```
-
-```text
-docs(onboarding): clarify setup prerequisites
-
-Why:
-- New environment variables were added without matching onboarding guidance.
-
-What:
-- Add setup prerequisites and an environment variable table.
-- Clarify the local development workflow.
-
-Impact:
-- Faster onboarding; no runtime behavior changes.
-
-Tests:
-- not run (docs-only change)
-
-Refs:
-- DOCS-45
-```
+- Reuse terms already present in the code, issue, or repository vocabulary.
+- Keep code values such as `completed` unchanged when no established Chinese
+  term exists.
+- Do not coin noun stacks such as "完成态缓存恢复函数" or "完成态边界".
+- Prefer a plain verb phrase such as "重命名缓存恢复函数" over a more compressed
+  but less natural technical label.
+- Do not hard-wrap inside an identifier. Wrap surrounding prose or omit a long
+  identifier when the established project noun is sufficient.
 
 ## Body Quality Bar
 
 ### Why
 
-- Explain why the change is necessary, not merely desired.
-- Include the trigger signal, affected audience, and the cost of not acting
-  when that context is material.
-- Write diagnostically: facts first, conclusion second.
+- State the concrete previous behavior, trigger, or maintenance pressure.
+- Explain why the change was necessary, not merely desirable.
+- Use domain nouns from the issue or diff instead of generic phrases such as
+  "there was confusion" or "consistency needed improvement."
+- Do not repeat the subject in past tense.
+- Do not explain why a test was added or speculate that it will prevent a
+  future regression.
 
 ### What
 
-- Describe the resulting change, not the implementation process.
-- Every bullet should be verifiable in code, docs, or tests.
-- Exclude low-level implementation trivia unless it is part of the delivered
-  outcome.
+- State the resulting behavior or structural change.
+- Use real function names, state values, or contract terms when they make the
+  change verifiable and easier to locate.
+- When both rename identifiers are long, name only the new identifier; the diff
+  already records the old one.
+- Every bullet must be supported by the staged diff or tests.
+- Leave test additions and assertions to `Tests` unless tests are the primary
+  change.
+- Do not report how many call sites were updated; a rename already implies
+  updating its callers.
 
 ### Impact
 
-- Focus on user, interface, release, or operational impact.
-- Explain who is affected, what behavior or contract changes, and any rollout,
-  migration, or rollback implications.
+- State the observable user, interface, runtime, release, or maintenance
+  boundary.
+- For a behavior-preserving refactor, identify the behavior that remains
+  unchanged instead of claiming only that code is "clearer."
+- Do not claim that a change is safer, faster, clearer, or more reliable unless
+  supplied evidence demonstrates that result.
+- State migration, rollout, or compatibility consequences when they exist.
+- For a local rename, one short behavior-preservation statement is enough. Do
+  not enumerate every state returned by the function.
 
 ### Tests
 
-- State what actually ran.
-- Use exactly one `Tests:` section.
+- State what actually ran and whether it passed.
 - Put every test, compile command, lint command, manual check, or skipped-test
-  reason as a bullet under that single section.
-- If tests did not run, use one of these forms:
-  - `not run (manual run pending)`
+  reason under the single `Tests` section.
+- If tests did not run, use a real reason such as:
   - `not run (docs-only change)`
   - `not run (config-only change)`
   - `not run (blocked: <reason>)`
@@ -199,19 +215,149 @@ Refs:
 
 ### Refs
 
-- Use `Refs` for decision and context traceability, not as an attachment dump.
-- `n/a` is acceptable only when no external issue, spec, incident, or PR is
-  relevant.
-- High-risk changes should always trace back to an issue, spec, incident, or
-  PR.
-- If `issue-gate-skill` returned a `refs_line`, prefer it directly.
+- Record verified decision and context references, not an attachment list.
+- If `issue-gate-skill` returned a `refs_line`, use it directly as the bullet
+  content unless repository policy requires another representation.
+- Use `n/a` only when no canonical issue, spec, incident, or PR applies and
+  repository policy permits that fallback.
+- Never invent a reference.
 
-## Format Rules
+## Type Selection
 
-- Follow the exact section order shown above.
-- Include each required section exactly once.
-- Do not add extra sections.
-- Do not repeat a section heading to list another item.
-- Combine multiple test commands under one `Tests:` heading as separate
-  bullets.
-- Single-line commit messages are not allowed.
+- `feat`: adds a user-facing capability.
+- `bugfix`: changes incorrect behavior on the normal release cadence.
+- `hotfix`: restores or mitigates urgent production behavior.
+- `refactor`: changes code structure without changing runtime behavior.
+- `docs`: changes documentation only.
+- `test`: changes test coverage without production or documentation changes.
+- `chore`: changes tooling, dependencies, generated artifacts, or maintenance
+  configuration.
+
+Choose the type from the staged result, not the author's motivation:
+
+- A rename plus a test that records existing behavior is `refactor`.
+- A change that makes an empty matrix produce `completed` when it previously
+  did not is `bugfix`.
+- A test that exposes a defect without changing production behavior is `test`.
+- Use `hotfix` only when the evidence establishes urgent production impact.
+
+When the message claims both "behavior is unchanged" and "the incorrect result
+is now corrected," stop and inspect the diff. Those claims require different
+commit types or a split.
+
+## Full Examples
+
+### Behavior-Preserving Rename
+
+Evidence: the staged production diff only renames
+`restore_response_matrix_extract_status_from_cache` to
+`restore_completed_response_matrix_status` and updates its callers. The
+empty-matrix test records behavior that already passed before the rename.
+
+```text
+refactor(response-check): 重命名缓存恢复函数
+
+Why:
+- 原名称暗示会恢复所有抽取状态，实际只处理 completed 缓存结果。
+
+What:
+- 将缓存恢复函数改名为 restore_completed_response_matrix_status。
+
+Impact:
+- 缓存恢复和响应检查行为不变。
+
+Tests:
+- PASS: pytest tests/test_response_check.py -k empty_matrix_cache
+
+Refs:
+- ISSUE: #168
+```
+
+### Behavior Correction
+
+Evidence: the staged production diff changes empty-matrix cache handling from
+failure to `completed`.
+
+```text
+bugfix(response-check): 将空矩阵缓存恢复为 completed
+
+Why:
+- 空矩阵是有效的已完成结果，但缓存恢复路径此前将它当作抽取失败。
+
+What:
+- 允许缓存恢复路径接受空矩阵，并返回 completed 状态。
+
+Impact:
+- 命中空矩阵缓存的任务不再被错误标记为抽取失败。
+
+Tests:
+- PASS: pytest tests/test_response_check.py -k empty_matrix_cache
+
+Refs:
+- ISSUE: #168
+```
+
+### Documentation Change Without External Reference
+
+```text
+docs(onboarding): 补充本地启动所需环境变量
+
+Why:
+- 启动命令已经读取 CACHE_URL，但入门文档没有说明该变量。
+
+What:
+- 在本地环境变量表中补充 CACHE_URL 的用途和示例值。
+
+Impact:
+- 读者可以仅按入门文档完成本地配置；运行时代码不变。
+
+Tests:
+- PASS: markdownlint docs/onboarding.md
+
+Refs:
+- n/a
+```
+
+## Anti-Patterns
+
+| Evidence | Avoid | Prefer |
+|---|---|---|
+| Rename `restore_response_matrix_extract_status_from_cache`. | `refactor(response-check): 明确已完成缓存恢复职责` | `refactor(response-check): 重命名缓存恢复函数` |
+| Rename a cache helper that only handles `completed`. | `refactor(response-check): 重命名完成态缓存恢复函数` | `refactor(response-check): 重命名缓存恢复函数` |
+| Empty extraction results must fail validation. | `bugfix(response-check): 修正抽取状态一致性` | `bugfix(response-check): 将空抽取结果标记为检查失败` |
+| Later validation overwrites an extraction failure. | `bugfix(response-check): 优化抽取失败处理` | `bugfix(response-check): 保留抽取失败状态` |
+| Token validation is duplicated in three handlers. | `refactor(auth): 理清令牌校验边界` | `refactor(auth): 提取重复的令牌校验` |
+
+The preferred wording is valid only when the evidence column matches the
+staged change. These examples teach evidence-to-language mapping; they do not
+authorize invented facts or identifiers.
+
+For the behavior-preserving rename example, reject this overloaded body shape:
+
+| Section | Avoid | Prefer |
+|---|---|---|
+| `Why` | `空矩阵也是有效缓存结果，需要用测试固定其完成态边界，避免后续重新引入失败状态判断。` | Omit it; test motivation and speculative regressions do not explain the production rename. |
+| `What` | `同步两处工作流调用，并验证 completed、100% 且无错误。` | State the rename once; report the check under `Tests`. |
+| `Impact` | `成功和空矩阵返回 completed，缺失缓存返回 None；运行时抽取失败仍写入 error。` | `缓存恢复和响应检查行为不变。` |
+
+## Verification
+
+Before accepting a message, confirm:
+
+- [ ] The staged diff supports the selected type and scope.
+- [ ] The subject contains a concrete action and real object.
+- [ ] The subject passes all four reader checks.
+- [ ] The message contains exactly one `Why`, `What`, `Impact`, `Tests`, and
+      `Refs` section in that order.
+- [ ] `Why` names the previous problem or trigger.
+- [ ] `What` names the actual behavior or structural change.
+- [ ] `Impact` names an observable result or precisely preserved boundary.
+- [ ] `Tests` reports every relevant check that actually ran, or a real
+      operational reason for not running it.
+- [ ] `Refs` contains only verified traceability or an allowed `n/a` fallback.
+- [ ] `Why -> What -> Impact` reads as one causal chain.
+- [ ] Each supporting detail appears in its owning location only.
+- [ ] Every section has one bullet unless another independent fact is required.
+- [ ] The message uses established project terms and no coined noun stack.
+- [ ] No generic benefit, vague intent phrase, invented identifier, or
+      unsupported impact remains.

--- a/agent-specs/engineering/skills/engineering-communication/README.md
+++ b/agent-specs/engineering/skills/engineering-communication/README.md
@@ -7,11 +7,16 @@ reader-friendly communication artifacts.
 
 | Skill | Use when |
 | --- | --- |
+| [`html-report-plan`](html-report-workflow/html-report-plan/SKILL.md) | An investigation, analysis, or implementation topic needs a report plan before HTML is written. |
+| [`html-report-build`](html-report-workflow/html-report-build/SKILL.md) | An approved report plan should become a self-contained local HTML report. |
+| [`html-report-review`](html-report-workflow/html-report-review/SKILL.md) | A generated HTML report needs review against its plan, evidence, readability, and safety requirements. |
 | [`project-flowchart-template-skill`](project-flowchart-template-skill/SKILL.md) | A project needs reusable Mermaid flowchart templates grounded in code evidence. |
 | [`summary-writing-skill`](summary-writing-skill/SKILL.md) | Daily, weekly, monthly, quarterly, or yearly work summaries need clear business-facing phrasing. |
 
 ## Usage Notes
 
-Use `project-flowchart-template-skill` for technical system communication and
-`summary-writing-skill` for progress reporting. Keep generated summaries and
-diagrams close to the audience or project area that owns them.
+Use the HTML report workflow as `$html-report-plan` -> `$html-report-build` ->
+`$html-report-review` when the artifact is a local static report. Use
+`project-flowchart-template-skill` for technical system communication and
+`summary-writing-skill` for progress reporting. Keep generated reports,
+summaries, and diagrams close to the audience or project area that owns them.

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/README.md
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/README.md
@@ -1,0 +1,21 @@
+# HTML Report Workflow
+
+Use this package when investigation, design rationale, comparison, or
+implementation guidance should become a local, evidence-backed HTML report.
+
+## Skills
+
+| Skill | Use when |
+| --- | --- |
+| [`html-report-plan`](html-report-plan/SKILL.md) | Define the report goal, audience, source context, claims, evidence, sections, and quality bar before writing HTML. |
+| [`html-report-build`](html-report-build/SKILL.md) | Create a self-contained static HTML report from an approved plan without adding unsupported claims. |
+| [`html-report-review`](html-report-review/SKILL.md) | Check the generated HTML report against the plan, evidence model, local usability, placeholders, and sensitive-data rules. |
+
+## Sequence
+
+1. `$html-report-plan`
+2. `$html-report-build`
+3. `$html-report-review`
+
+Use only the phase the user asks for when a valid upstream artifact already
+exists.

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-build/SKILL.md
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-build/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: html-report-build
+description: v0.1.0 - Builds a local self-contained HTML report from an approved report plan. Use when a report plan exists and the user wants a readable HTML artifact written to a target directory without adding new claims or changing the report scope.
+---
+
+# HTML Report Build
+
+## Overview
+
+Create a local HTML report from an approved report plan. This skill translates
+the plan into a self-contained `.html` file with readable structure, restrained
+styling, clear evidence labels, and explicit unknowns.
+
+The build phase does not re-plan the report. It follows the report goal,
+sections, claims, and quality bar from `html-report-plan`.
+It also follows the planned page organization instead of inventing layout or
+reading order during implementation.
+
+## When to Use
+
+- A report plan exists and the user wants the HTML file created.
+- The output should be a static local report, not an app or website.
+- The report should be readable offline with inline CSS.
+- The user provides a target directory or asks to place the report in a local
+  folder.
+
+**When NOT to use:** before the report plan exists, when the user wants an
+interactive UI, when source claims still need investigation, or when the output
+belongs in released project documentation.
+
+## The Build Process
+
+### Step 1: Load the Report Plan
+
+Read the report plan from the current conversation or a provided file. Confirm:
+
+- report goal
+- audience
+- output directory and filename
+- source context
+- claims and evidence status
+- section order
+- page organization: reading path, layout model, evidence placement, visual
+  grouping, scan aids, and mobile notes
+- quality bar
+
+If no usable plan exists, stop and ask for `html-report-plan`.
+
+### Step 2: Confirm the Output Path
+
+Use the user-provided target directory when available. Create the directory if
+it does not exist. Choose a stable filename such as
+`<topic>-report.html` when the user did not provide one.
+
+Do not write outside the requested or inferred target directory.
+
+### Step 3: Compose the Report
+
+Write sections from the plan:
+
+- executive summary or overview
+- findings and evidence
+- recommendations or implementation guidance
+- risks and tradeoffs
+- open questions or unverified assumptions
+- evidence appendix when useful
+
+Keep facts, inferences, recommendations, and unknowns visually distinct.
+Follow the planned reading path, layout model, evidence placement, scan aids,
+and mobile notes. If the page organization is impossible with static HTML,
+stop and revise the plan instead of inventing a different report shape.
+
+### Step 4: Build One Self-Contained HTML File
+
+Use `assets/html-report-template.html` as the structural baseline:
+
+- inline CSS
+- semantic headings
+- readable typography
+- responsive width
+- tables or callouts only when they improve scanning
+- no remote assets unless explicitly allowed
+- no decorative landing-page hero unless the user asked for a public-facing
+  page
+
+### Step 5: Verify the File
+
+Before reporting success:
+
+- confirm the file exists at the target path
+- confirm it has valid basic HTML structure
+- search for unresolved placeholders
+- confirm key sections from the plan appear
+- confirm the page organization from the plan is reflected
+- confirm unverified items are labeled
+- confirm no secrets or private data were inserted
+
+Use a browser screenshot only when visual inspection is needed or the user asks
+for rendered validation.
+
+## Decision Points
+
+- If the plan and source context disagree, stop and ask instead of choosing
+  silently.
+- If the target path is ambiguous, pick the requested directory and a
+  descriptive filename; ask only when the directory itself is unclear.
+- If the report needs new investigation, stop and return to planning or
+  research; do not add unsupported claims during build.
+- If the user asks for an app, dashboard, or interactive controls, route to
+  frontend work instead of this static report skill.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The report will be better if I add a few extra conclusions." | Build follows the plan. New conclusions need evidence and plan revision. |
+| "A fancy hero will make it look professional." | Engineering reports should prioritize evidence, scanning, and clarity. |
+| "External fonts and CDNs are fine." | Local reports should be self-contained unless assets are explicitly allowed. |
+| "Unknowns make the report look weaker." | Labeled unknowns make the report trustworthy. |
+| "I can choose the layout while coding." | Page organization is part of the plan contract; build executes it. |
+
+## Red Flags
+
+- HTML is created without a report plan.
+- The report introduces major claims not present in the plan.
+- The report ignores the planned reading path, evidence placement, or scan
+  aids.
+- Facts, inferences, and recommendations are visually indistinguishable.
+- The output depends on remote assets without approval.
+- The file contains placeholders such as `TODO`, `TBD`, or `<section>`.
+- The report reads like a marketing page instead of an engineering report.
+
+## Verification
+
+- [ ] Report plan was loaded.
+- [ ] Output directory and filename were resolved.
+- [ ] HTML file exists.
+- [ ] Basic HTML structure is present.
+- [ ] Planned sections are present.
+- [ ] Planned page organization is reflected in the HTML.
+- [ ] Unsupported claims and unknowns are labeled.
+- [ ] No unresolved placeholders remain.
+- [ ] No secrets, credentials, or private data were added.
+
+## Output Format
+
+```text
+## Report Built
+- path:
+- status:
+
+## Source Plan
+- report_goal:
+- audience:
+
+## Verification
+- file_exists:
+- sections_present:
+- page_organization_followed:
+- placeholders:
+- sensitive_data_check:
+
+## Gaps
+- none | <gap>
+```
+
+## Guardrails
+
+- Do not invent evidence, inspected files, command output, or source links.
+- Do not rewrite the report plan while building.
+- Do not invent a different page organization when the plan already defines
+  one.
+- Do not auto-commit the report.
+- Do not use external assets unless explicitly allowed.
+- Do not put secrets, credentials, private data, or raw sensitive logs in the
+  report.
+
+## Assets
+
+- `assets/html-report-template.html`
+  Self-contained HTML report starter.

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-build/agents/openai.yaml
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-build/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HTML Report Build"
+  short_description: "v0.1.0 - Build a self-contained HTML report from a plan"
+  default_prompt: "Use $html-report-build to create a local self-contained HTML report from the approved report plan, without adding unsupported claims or changing the report scope."

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-build/assets/html-report-template.html
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-build/assets/html-report-template.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{REPORT_TITLE}}</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --paper: #ffffff;
+      --text: #1f2933;
+      --muted: #617083;
+      --line: #d9e0e8;
+      --accent: #2f6f73;
+      --warn: #8a5a00;
+      --danger: #9b2c2c;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+    main {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 40px 24px 56px;
+    }
+    article {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 32px;
+    }
+    h1, h2, h3 {
+      line-height: 1.2;
+      margin: 0 0 12px;
+    }
+    h1 {
+      font-size: 2rem;
+    }
+    h2 {
+      margin-top: 32px;
+      padding-top: 20px;
+      border-top: 1px solid var(--line);
+      font-size: 1.35rem;
+    }
+    p, ul, ol, table {
+      margin-top: 0;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 16px 0;
+      font-size: 0.95rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 10px 12px;
+      vertical-align: top;
+    }
+    th {
+      background: #eef3f6;
+      text-align: left;
+    }
+    .meta, .muted {
+      color: var(--muted);
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: #eef7f6;
+      padding: 12px 16px;
+      margin: 16px 0;
+    }
+    .warning {
+      border-left-color: var(--warn);
+      background: #fff8e8;
+    }
+    .danger {
+      border-left-color: var(--danger);
+      background: #fff0f0;
+    }
+    .tag {
+      display: inline-block;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 2px 8px;
+      margin-right: 6px;
+      color: var(--muted);
+      font-size: 0.82rem;
+    }
+    code {
+      background: #eef1f4;
+      border-radius: 4px;
+      padding: 1px 4px;
+    }
+    @media (max-width: 720px) {
+      main {
+        padding: 20px 12px 36px;
+      }
+      article {
+        padding: 22px 16px;
+      }
+      table {
+        display: block;
+        overflow-x: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <article>
+      <header>
+        <p class="meta">{{REPORT_META}}</p>
+        <h1>{{REPORT_TITLE}}</h1>
+        <p>{{REPORT_SUMMARY}}</p>
+      </header>
+
+      {{REPORT_BODY}}
+    </article>
+  </main>
+</body>
+</html>

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-plan/SKILL.md
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-plan/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: html-report-plan
+description: v0.1.0 - Plans an evidence-backed HTML report before writing HTML. Use when analysis, investigation, design rationale, comparison, or implementation guidance should become a local HTML report with clear audience, claims, evidence, page organization, structure, and quality bar.
+---
+
+# HTML Report Plan
+
+## Overview
+
+Plan a local HTML report before generating the file. This skill turns a loose
+request such as "make an HTML report" into a writing contract: purpose,
+audience, source context, claims, page organization, report structure, evidence
+requirements, and quality bar.
+
+The output is a report plan, not HTML. Use `html-report-build` after the plan is
+accepted or clear enough to execute.
+
+## When to Use
+
+- The user asks for an HTML report, visual report, investigation report, or
+  shareable analysis artifact.
+- The report needs to organize code findings, architecture decisions, product
+  tradeoffs, technical recommendations, or operational guidance.
+- The evidence, claims, and audience need to be separated before writing.
+- A previous report looked polished but mixed facts, assumptions, and advice.
+
+**When NOT to use:** tiny one-paragraph summaries, released project docs,
+marketing pages, dashboards, or UI applications. Use project documentation
+skills for durable docs and frontend skills for interactive apps.
+
+## The Planning Process
+
+### Step 1: Define the Report Job
+
+Identify:
+
+- report topic
+- target reader
+- decision or action the report should support
+- target output directory or filename when supplied
+- language and tone
+
+If the user only gives a directory, infer a filename from the topic and ask only
+when the report subject itself is unclear.
+
+### Step 2: Gather Source Context
+
+List the evidence inputs the report may use:
+
+- local files and code paths
+- command outputs
+- previous chat analysis
+- diagrams, screenshots, traces, or logs
+- external sources only when browsing was explicitly requested or required
+
+Separate facts already inspected from context that still needs verification.
+Do not invent facts to make the report feel complete.
+
+### Step 3: Classify Claims
+
+Organize report content into:
+
+- `facts`: directly supported by inspected evidence
+- `inferences`: reasoned conclusions based on facts
+- `recommendations`: proposed actions or designs
+- `unknowns`: unresolved questions or unverified assumptions
+
+Every major recommendation should trace back to facts or be clearly labeled as
+an inference.
+
+### Step 4: Design the Report Structure
+
+Choose sections for the reader and purpose. Common sections:
+
+- executive summary
+- current state
+- key findings
+- recommended approach
+- implementation plan
+- risks and tradeoffs
+- evidence appendix
+- open questions
+
+Avoid landing-page structure unless the user asked for a public-facing page.
+Engineering reports should prioritize dense, readable evidence over decorative
+composition.
+
+### Step 5: Design the Page Organization
+
+Define how the HTML page should explain the report, not only which sections it
+contains:
+
+- top-level reading path: what the reader sees first, second, and last
+- layout model: single-column report, sidebar/table-of-contents, section cards,
+  comparison table, timeline, appendix-heavy report, or another explicit shape
+- evidence placement: inline references, source table, appendix, or callouts
+- visual grouping: how facts, inferences, recommendations, and unknowns are
+  separated
+- scan aids: summary block, key finding list, status badges, risk table, or
+  decision matrix when useful
+- mobile behavior: how wide tables, code blocks, and dense evidence remain
+  readable
+
+The page organization should make the argument understandable before any CSS is
+written. Do not leave layout decisions for `html-report-build` to invent.
+
+### Step 6: Define the Quality Bar
+
+Write acceptance criteria for the final HTML:
+
+- can be opened locally
+- uses a single self-contained HTML file unless assets are explicitly allowed
+- separates facts, inferences, recommendations, and unknowns
+- follows the planned page organization and reading path
+- marks unverified items clearly
+- includes evidence references for key claims
+- uses restrained styling that supports scanning
+- avoids secrets, credentials, private data, and unsupported claims
+
+### Step 7: Produce or Persist the Plan
+
+Write the plan using `references/report-plan-template.yaml` or the same fields
+in readable Markdown. If the user gave a target directory, write the plan there
+as `<report-name>.plan.yaml` so `html-report-build` can load the exact
+contract. If no target directory is known, output the complete plan in the
+conversation. Do not create the HTML file in this skill.
+
+## Decision Points
+
+- If the report goal is unclear, ask for the report topic before planning.
+- If evidence is insufficient, include a source gap instead of fabricating
+  findings.
+- If the user asks for released documentation, route to project documentation
+  skills instead of HTML report workflow.
+- If the user asks for an interactive app or dashboard, route to frontend work
+  instead of a static report.
+- If sensitive material appears in source context, exclude it or redact it in
+  the plan.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I can just write the HTML and make it look good." | Visual polish cannot repair weak claims or missing evidence. |
+| "The chat history is enough evidence." | Chat history must still be separated into facts, inferences, recommendations, and unknowns. |
+| "A report plan is overkill." | Reports are high-freedom writing; planning prevents polished but unreliable output. |
+| "I'll decide sections while building." | Structure is the contract that keeps the report focused. |
+| "The layout is just CSS." | Page organization determines how the reader understands the argument before styling exists. |
+
+## Red Flags
+
+- The plan has sections but no report goal or reader.
+- Claims are listed without evidence or source status.
+- The plan treats unverified assumptions as facts.
+- The plan asks for a marketing-style landing page for an engineering report.
+- The plan lists sections but does not define a reading path or page
+  organization.
+- The plan does not define how the final HTML will be checked.
+
+## Verification
+
+- [ ] Report goal and audience are explicit.
+- [ ] Source context is listed and classified by evidence status.
+- [ ] Facts, inferences, recommendations, and unknowns are separated.
+- [ ] Report sections match the reader and decision.
+- [ ] Page organization explains the reading path, layout model, evidence
+      placement, and scan aids.
+- [ ] Final HTML quality bar is concrete and checkable.
+- [ ] Plan was written to `<report-name>.plan.yaml` when a target directory was
+      known, or fully output in the conversation when no path was known.
+- [ ] No HTML file was created.
+
+## Output Format
+
+```text
+## Report Goal
+## Audience
+## Source Context
+## Claims and Evidence
+## Report Structure
+## Page Organization
+## Quality Bar
+## Open Questions
+## Build Handoff
+```
+
+## Guardrails
+
+- Do not create or edit the HTML report in this skill.
+- Do not invent evidence, command output, files, screenshots, or external
+  sources.
+- Do not leave page organization, evidence placement, or reading path for build
+  time when the report is non-trivial.
+- Do not store secrets, credentials, private data, or raw sensitive logs in the
+  plan.
+- Do not convert the plan into released project documentation.
+- Do not optimize for decoration before the evidence model is clear.
+
+## References
+
+- `references/report-plan-template.yaml`
+  Structured report plan template for handoff to `html-report-build`.

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-plan/agents/openai.yaml
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HTML Report Plan"
+  short_description: "v0.1.0 - Plan an evidence-backed HTML report"
+  default_prompt: "Use $html-report-plan to define the report goal, audience, claims, evidence, page organization, structure, quality bar, and plan artifact before creating any HTML."

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-plan/references/report-plan-template.yaml
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-plan/references/report-plan-template.yaml
@@ -1,0 +1,60 @@
+schema_version: 0.1
+report_goal: "<what decision, understanding, or action this report should support>"
+audience: "<primary reader>"
+output:
+  directory: "<target directory or unknown>"
+  filename: "<target html filename or proposed name>"
+  language: "<report language>"
+source_context:
+  inspected:
+    - "<file, command output, conversation analysis, or source>"
+  needs_verification:
+    - "<source or claim that still needs checking>"
+claims:
+  facts:
+    - claim: "<directly supported fact>"
+      evidence:
+        - "<source reference>"
+  inferences:
+    - claim: "<reasoned conclusion>"
+      based_on:
+        - "<fact or evidence>"
+  recommendations:
+    - claim: "<proposed action>"
+      rationale:
+        - "<why this follows from the evidence>"
+  unknowns:
+    - "<unresolved question or unverified assumption>"
+sections:
+  - title: "<section title>"
+    purpose: "<why this section belongs>"
+    primary_claims:
+      - "<claim ids or short claim labels this section explains>"
+page_organization:
+  reading_path:
+    - "<what the reader should understand first>"
+    - "<what the reader should inspect next>"
+    - "<what decision or action the reader should reach last>"
+  layout_model: "<single-column report | sidebar toc | comparison table | timeline | appendix-heavy report | other explicit shape>"
+  top_summary:
+    purpose: "<what the first viewport or opening block should clarify>"
+    contents:
+      - "<summary item, status, or key finding>"
+  section_pattern: "<how repeated sections should be organized>"
+  evidence_placement: "<inline references | source table | appendix | callouts | mixed>"
+  visual_grouping:
+    facts: "<how facts are labeled or grouped>"
+    inferences: "<how inferences are labeled or grouped>"
+    recommendations: "<how recommendations are labeled or grouped>"
+    unknowns: "<how unknowns are labeled or grouped>"
+  scan_aids:
+    - "<summary list, risk table, decision matrix, status badge, or other scan aid>"
+  mobile_notes:
+    - "<how wide tables, code blocks, or dense evidence stay readable>"
+quality_bar:
+  - "<checkable acceptance criterion>"
+build_constraints:
+  - "single self-contained HTML file unless assets are explicitly allowed"
+  - "facts, inferences, recommendations, and unknowns are visually distinct"
+  - "page organization follows the planned reading path, layout model, evidence placement, and scan aids"
+  - "no secrets, credentials, private data, or unsupported claims"

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/SKILL.md
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: html-report-review
+description: v0.1.0 - Reviews a generated HTML report against its report plan, evidence, and local-readability requirements. Use when an HTML report should be checked for factual grounding, claim labeling, structure, offline usability, placeholders, and sensitive data before sharing.
+---
+
+# HTML Report Review
+
+## Overview
+
+Review a generated HTML report against the plan that authorized it. This skill
+checks whether the report is accurate, evidence-backed, locally readable, and
+clear about facts, inferences, recommendations, and unknowns.
+
+The review phase does not rewrite the report by default. It reports findings
+and concrete next actions.
+
+## When to Use
+
+- An HTML report has been generated and needs acceptance review.
+- The report will be shared with a human decision-maker.
+- The report contains technical findings, recommendations, or implementation
+  guidance that must be evidence-backed.
+- A report looks polished but may contain unsupported claims or missing
+  caveats.
+
+**When NOT to use:** before the HTML file exists, for general code review, for
+marketing copy review, or for project documentation lifecycle review.
+
+## The Review Process
+
+### Step 1: Load Inputs
+
+Read:
+
+- the report plan
+- the generated HTML file
+- any source context or evidence references available
+
+If the plan is missing, review the HTML as `plan_missing` and state the reduced
+confidence.
+
+### Step 2: Check Plan Adherence
+
+Verify:
+
+- report goal is addressed
+- intended audience is respected
+- planned sections are present or deviations are explained
+- planned page organization is followed, including reading path, layout model,
+  evidence placement, visual grouping, scan aids, and mobile notes
+- quality bar is met
+- unknowns and gaps from the plan remain visible
+
+### Step 3: Check Evidence and Claim Labeling
+
+Classify major statements:
+
+- facts with evidence
+- inferences with rationale
+- recommendations with rationale
+- unknowns or assumptions
+
+Flag any major claim that lacks support or presents inference as fact.
+
+### Step 4: Check HTML Usability
+
+Verify:
+
+- file exists and opens as static HTML
+- basic structure has `doctype`, `html`, `head`, `title`, and `body`
+- content is readable without external assets unless allowed
+- tables or code blocks do not destroy mobile readability
+- headings form a useful scan path
+- opening summary, evidence placement, and scan aids match the plan when the
+  plan defines them
+
+### Step 5: Check Safety and Completeness
+
+Scan for:
+
+- placeholders such as `TODO`, `TBD`, `{{...}}`
+- broken local references
+- secrets, credentials, private data, or raw sensitive logs
+- missing evidence appendix when evidence is central
+- over-decorated layout that hides substance
+
+### Step 6: Decide the Result
+
+Use:
+
+- `pass`: report matches the plan, claims are grounded, HTML is locally usable,
+  and no blocking safety issue exists.
+- `fail`: report has unsupported major claims, missing required sections,
+  unsafe content, or serious usability problems.
+- `blocked`: required files or evidence are missing, preventing a meaningful
+  review.
+
+## Decision Points
+
+- If unsupported claims are minor, recommend edits and mark the result `fail`
+  until fixed.
+- If the plan is missing but the user still wants review, proceed with reduced
+  confidence and mark plan adherence as `blocked`.
+- If sensitive content appears, fail the review and identify the area without
+  repeating the sensitive value.
+- If the report needs new research, recommend returning to `html-report-plan`
+  or an investigation step.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It opens in the browser, so it passes." | A report can render while still being unsupported or misleading. |
+| "The design looks polished." | Visual polish is secondary to evidence, claim labeling, and readability. |
+| "The reader can infer what is uncertain." | Unknowns and assumptions must be explicit. |
+| "I can fix it while reviewing." | Review reports findings; rewriting is a separate build pass unless requested. |
+| "The page organization is subjective." | The plan's reading path and evidence placement are reviewable acceptance criteria. |
+
+## Red Flags
+
+- Major recommendations have no cited fact or rationale.
+- Inferences are written as facts.
+- The report contains unresolved placeholders.
+- The report uses remote assets without approval.
+- The report ignores the planned reading path or evidence placement.
+- The report hides unknowns or omits risks from the plan.
+- The review rewrites the report instead of producing findings.
+
+## Verification
+
+- [ ] Report plan was read or missing-plan status was declared.
+- [ ] HTML file was read.
+- [ ] Planned sections were checked.
+- [ ] Planned page organization was checked.
+- [ ] Major claims were checked for evidence or rationale.
+- [ ] Static HTML usability was checked.
+- [ ] Placeholders and sensitive data were scanned.
+- [ ] Result is `pass`, `fail`, or `blocked`.
+
+## Output Format
+
+```text
+## Review Result
+- result:
+- report:
+- plan:
+
+## Plan Adherence
+- findings:
+- page_organization:
+
+## Evidence and Claims
+- unsupported_claims:
+- mislabeled_inferences:
+
+## HTML Usability
+- findings:
+
+## Safety and Completeness
+- placeholders:
+- sensitive_data:
+- missing_sections:
+
+## Next Actions
+- none | <actions>
+```
+
+## Guardrails
+
+- Do not rewrite the HTML unless the user explicitly asks for repair.
+- Do not expose secrets or private data found during review.
+- Do not invent evidence to make a claim pass.
+- Do not treat visual polish as a substitute for evidence.
+- Do not mark `pass` when plan adherence is blocked or major claims are
+  unsupported.
+
+## References
+
+- `references/review-checklist.md`
+  Checklist for HTML report acceptance review.

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/SKILL.md
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: html-report-review
-description: v0.1.0 - Reviews a generated HTML report against its report plan, evidence, and local-readability requirements. Use when an HTML report should be checked for factual grounding, claim labeling, structure, offline usability, placeholders, and sensitive data before sharing.
+description: v0.1.0 - Reviews a generated HTML report against its current scenario, report plan, evidence, and local-readability requirements. Use when an HTML report should be checked for scenario fit, intuitive communication, factual grounding, claim labeling, structure, offline usability, placeholders, and sensitive data before sharing.
 ---
 
 # HTML Report Review
@@ -8,8 +8,9 @@ description: v0.1.0 - Reviews a generated HTML report against its report plan, e
 ## Overview
 
 Review a generated HTML report against the plan that authorized it. This skill
-checks whether the report is accurate, evidence-backed, locally readable, and
-clear about facts, inferences, recommendations, and unknowns.
+checks whether the report is appropriate for the current scenario, intuitive
+for its intended reader, accurate, evidence-backed, locally readable, and clear
+about facts, inferences, recommendations, and unknowns.
 
 The review phase does not rewrite the report by default. It reports findings
 and concrete next actions.
@@ -22,6 +23,9 @@ and concrete next actions.
   guidance that must be evidence-backed.
 - A report looks polished but may contain unsupported claims or missing
   caveats.
+- A report needs a judgment on whether HTML is the right artifact for the
+  situation, or whether a doc, table, PR note, diagram, or task plan would serve
+  the reader better.
 
 **When NOT to use:** before the HTML file exists, for general code review, for
 marketing copy review, or for project documentation lifecycle review.
@@ -35,11 +39,27 @@ Read:
 - the report plan
 - the generated HTML file
 - any source context or evidence references available
+- the current scenario, audience, and intended use from the user request or
+  plan
 
 If the plan is missing, review the HTML as `plan_missing` and state the reduced
 confidence.
 
-### Step 2: Check Plan Adherence
+### Step 2: Check Scenario Fit
+
+Judge whether this HTML report is the right artifact for the current situation:
+
+- the report answers the user's actual question or decision need
+- the audience, depth, and tone match the intended reader
+- the report format is appropriate compared with alternatives such as a project
+  doc, summary, table, PR/MR description, flowchart, task plan, or dashboard
+- the scope is neither too broad to act on nor too narrow to explain the issue
+- the report's first screen makes the purpose and conclusion discoverable
+
+If HTML is not the right artifact, mark the result `fail` unless the user
+explicitly asked for HTML as the deliverable and the report is otherwise useful.
+
+### Step 3: Check Plan Adherence
 
 Verify:
 
@@ -51,7 +71,22 @@ Verify:
 - quality bar is met
 - unknowns and gaps from the plan remain visible
 
-### Step 3: Check Evidence and Claim Labeling
+### Step 4: Check Reader Intuition
+
+Judge whether the report is easy to understand in one pass:
+
+- the first screen or opening block states the useful conclusion, not just the
+  topic
+- headings form a clear scan path
+- the most important findings are visually prioritized
+- facts, inferences, recommendations, and unknowns are easy to distinguish
+- tables, callouts, and appendices reduce cognitive load instead of adding
+  decoration
+- the reader can tell what to do next without reading every detail
+
+Flag reports that are accurate but hard to use.
+
+### Step 5: Check Evidence and Claim Labeling
 
 Classify major statements:
 
@@ -62,7 +97,7 @@ Classify major statements:
 
 Flag any major claim that lacks support or presents inference as fact.
 
-### Step 4: Check HTML Usability
+### Step 6: Check HTML Usability
 
 Verify:
 
@@ -74,7 +109,7 @@ Verify:
 - opening summary, evidence placement, and scan aids match the plan when the
   plan defines them
 
-### Step 5: Check Safety and Completeness
+### Step 7: Check Safety and Completeness
 
 Scan for:
 
@@ -84,14 +119,16 @@ Scan for:
 - missing evidence appendix when evidence is central
 - over-decorated layout that hides substance
 
-### Step 6: Decide the Result
+### Step 8: Decide the Result
 
 Use:
 
-- `pass`: report matches the plan, claims are grounded, HTML is locally usable,
-  and no blocking safety issue exists.
+- `pass`: report fits the scenario, is intuitive for the reader, matches the
+  plan, claims are grounded, HTML is locally usable, and no blocking safety
+  issue exists.
 - `fail`: report has unsupported major claims, missing required sections,
-  unsafe content, or serious usability problems.
+  scenario mismatch, weak reader intuition, unsafe content, or serious
+  usability problems.
 - `blocked`: required files or evidence are missing, preventing a meaningful
   review.
 
@@ -105,6 +142,10 @@ Use:
   repeating the sensitive value.
 - If the report needs new research, recommend returning to `html-report-plan`
   or an investigation step.
+- If the report is well formed but the wrong artifact for the task, fail with a
+  replacement recommendation instead of only listing HTML issues.
+- If the report is accurate but not intuitive, fail with concrete reading-path
+  fixes.
 
 ## Common Rationalizations
 
@@ -115,9 +156,14 @@ Use:
 | "The reader can infer what is uncertain." | Unknowns and assumptions must be explicit. |
 | "I can fix it while reviewing." | Review reports findings; rewriting is a separate build pass unless requested. |
 | "The page organization is subjective." | The plan's reading path and evidence placement are reviewable acceptance criteria. |
+| "The user asked for HTML, so scenario fit is already solved." | Review still checks whether this HTML report actually serves the user's current decision or communication need. |
+| "Accurate means good enough." | A report can be accurate and still fail if the reader cannot quickly understand the point. |
 
 ## Red Flags
 
+- The report does not answer the user's actual decision or communication need.
+- HTML is the wrong artifact for the situation, but the review ignores that.
+- The first screen does not expose the purpose, conclusion, or next action.
 - Major recommendations have no cited fact or rationale.
 - Inferences are written as facts.
 - The report contains unresolved placeholders.
@@ -130,8 +176,10 @@ Use:
 
 - [ ] Report plan was read or missing-plan status was declared.
 - [ ] HTML file was read.
+- [ ] Current scenario, audience, and intended use were checked.
 - [ ] Planned sections were checked.
 - [ ] Planned page organization was checked.
+- [ ] Reader intuition and first-screen clarity were checked.
 - [ ] Major claims were checked for evidence or rationale.
 - [ ] Static HTML usability was checked.
 - [ ] Placeholders and sensitive data were scanned.
@@ -144,10 +192,21 @@ Use:
 - result:
 - report:
 - plan:
+- scenario_fit:
+- reader_intuition:
+
+## Scenario Fit
+- findings:
+- better_artifact_if_any:
 
 ## Plan Adherence
 - findings:
 - page_organization:
+
+## Reader Intuition
+- first_screen:
+- scan_path:
+- next_action_clarity:
 
 ## Evidence and Claims
 - unsupported_claims:
@@ -171,6 +230,8 @@ Use:
 - Do not expose secrets or private data found during review.
 - Do not invent evidence to make a claim pass.
 - Do not treat visual polish as a substitute for evidence.
+- Do not treat factual correctness as enough when the report fails the current
+  scenario or reader comprehension need.
 - Do not mark `pass` when plan adherence is blocked or major claims are
   unsupported.
 

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/agents/openai.yaml
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HTML Report Review"
+  short_description: "v0.1.0 - Review an HTML report against its plan and evidence"
+  default_prompt: "Use $html-report-review to check a generated HTML report for plan adherence, evidence grounding, claim labeling, local readability, placeholders, and sensitive data before sharing."

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/agents/openai.yaml
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "HTML Report Review"
-  short_description: "v0.1.0 - Review an HTML report against its plan and evidence"
-  default_prompt: "Use $html-report-review to check a generated HTML report for plan adherence, evidence grounding, claim labeling, local readability, placeholders, and sensitive data before sharing."
+  short_description: "v0.1.0 - Review an HTML report for scenario fit, clarity, plan adherence, and evidence"
+  default_prompt: "Use $html-report-review to check a generated HTML report for scenario fit, reader intuition, plan adherence, evidence grounding, claim labeling, local readability, placeholders, and sensitive data before sharing."

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/references/review-checklist.md
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/references/review-checklist.md
@@ -1,0 +1,35 @@
+# HTML Report Review Checklist
+
+## Plan Adherence
+
+- Report goal is addressed.
+- Audience and tone match the plan.
+- Planned sections are present or deviations are explained.
+- Planned reading path, layout model, evidence placement, visual grouping, and
+  scan aids are reflected in the HTML.
+- Quality bar items are checked.
+- Unknowns and gaps remain visible.
+
+## Evidence and Claims
+
+- Major facts cite or name evidence.
+- Inferences are labeled or phrased as inferences.
+- Recommendations include rationale.
+- Unsupported claims are flagged.
+- Unverified assumptions are not written as facts.
+
+## HTML Usability
+
+- File opens as static HTML.
+- Basic HTML structure is present.
+- No required remote assets unless approved.
+- Headings support scanning.
+- Tables and code blocks remain readable on narrow screens.
+
+## Safety and Completeness
+
+- No unresolved placeholders.
+- No secrets, credentials, private data, or raw sensitive logs.
+- No broken local references.
+- Evidence appendix exists when evidence is central.
+- Styling supports reading rather than decoration.

--- a/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/references/review-checklist.md
+++ b/agent-specs/engineering/skills/engineering-communication/html-report-workflow/html-report-review/references/review-checklist.md
@@ -1,5 +1,14 @@
 # HTML Report Review Checklist
 
+## Scenario Fit
+
+- Report answers the user's actual question, decision, or communication need.
+- Audience, depth, and tone match the intended reader.
+- HTML is an appropriate artifact compared with a project doc, table, PR/MR
+  description, flowchart, task plan, or dashboard.
+- Scope is actionable and not padded with unrelated material.
+- The first screen makes the purpose and conclusion discoverable.
+
 ## Plan Adherence
 
 - Report goal is addressed.
@@ -9,6 +18,15 @@
   scan aids are reflected in the HTML.
 - Quality bar items are checked.
 - Unknowns and gaps remain visible.
+
+## Reader Intuition
+
+- Opening block states the useful conclusion, not only the topic.
+- Headings form a clear scan path.
+- Important findings are visually prioritized.
+- Facts, inferences, recommendations, and unknowns are easy to distinguish.
+- Tables, callouts, and appendices reduce cognitive load.
+- Reader can identify the next action without reading every detail.
 
 ## Evidence and Claims
 


### PR DESCRIPTION
## Summary

- Add `html-report-plan`, `html-report-build`, and `html-report-review` skills with Codex metadata, planning/review references, and a self-contained HTML template.
- Extend HTML report review with scenario-fit, first-screen clarity, scan-path, and next-action gates.
- Upgrade `git-commit-skill` to v0.2.4 with evidence selection, information ownership, concise section defaults, and representative wording fixtures.

## Commit Breakdown

- `4bc7ab9` adds the HTML report workflow and routing documentation.
- `fa52a8f` strengthens the HTML report review acceptance gate.
- `23b9383` adds evidence and content ownership rules to Git commit drafting.

## Validation

- PASS: `git diff --check upstream/main...HEAD`
- PASS: branch diff credential scan
- PASS: skill frontmatter, Codex metadata, version, and default-prompt checks
- PASS: YAML parsing for skill metadata and the report plan template
- PASS: HTML template structure check
- PASS: Git commit full-example structure and overload failure fixtures

## Review Note

This draft intentionally combines the HTML report workflow and Git commit skill update at the operator's request. The changes have independent rollback boundaries, so they are organized as three atomic commits for commit-by-commit review.

## Refs

- n/a
