### PR TITLE
[codex] Make issue and commit writing behavior-first

### DIFF
--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-skill
-description: v0.2.4 - Draft, split, and execute atomic scoped Git commits with verified traceability and concise, concrete Why/What/Impact/Tests/Refs bodies. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
+description: v0.2.5 - Draft, split, and execute atomic scoped Git commits with verified traceability and behavior-first Why/What/Impact/Tests/Refs bodies. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
 ---
 
 # Git Commit Skill
@@ -15,6 +15,9 @@ The sections must tell one causal story without replacing observable changes
 with intent summaries such as "clarify responsibility" or "improve
 consistency." Each supporting detail appears once, in the section that owns
 it; repeat the core behavior only when needed to connect the causal chain.
+Describe background conditions, behavior changes, visible results, and tested
+boundaries in project language. Leave routine internal fields, file lists,
+helper names, commands, and pass markers to the diff or execution report.
 
 Use the existing commit-message and execution references for details. The
 always-loaded behavior is: inspect first, preserve unrelated changes, verify
@@ -56,11 +59,17 @@ issue mapping, and use review or CI skills for review/CI failures.
   another convention
 - commit body format: exact `Why / What / Impact / Tests / Refs`
 - section rule: each required body section appears exactly once; multiple
-  checks are bullets under the single `Tests` section
+  independent tested boundaries are bullets under the single `Tests` section
 - evidence rule: derive the subject and every section from the user request,
   issue, staged diff, or verification results
 - density rule: use one bullet with one sentence per section by default; add a
   second bullet only for a separate fact required to understand the commit
+- language rule: default every section to behavior-level prose; keep an
+  internal identifier only when it is a public contract, the direct change
+  object, or necessary to distinguish a state transition
+- tests rule: state the behavior or boundary covered and add the expected
+  result when it is material; keep commands and pass or fail results in the
+  execution report
 - execution mode: full commit execution for normal commit-stage work
 - split policy: atomic save-point commits, based on
   `commit-execution-policy.md`
@@ -84,6 +93,9 @@ issue mapping, and use review or CI skills for review/CI failures.
    - Run the branch/worktree checks described there.
    - Identify in-scope files, unrelated dirty files, generated files, and
      mixed-authorship files.
+   - When repository language is unclear, sample recent non-merge commits for
+     concrete verbs, background phrasing, behavior vocabulary, and testing
+     language. Do not replace this skill's required five-section structure.
    - Treat the save-point order as:
      `worktree -> issue -> verified slice -> issue-gate -> commit`.
 3. Run traceability gate when required.
@@ -102,8 +114,11 @@ issue mapping, and use review or CI skills for review/CI failures.
    - Read `references/commit-message-standard.md`.
    - Record the concrete primary action and object from the staged diff.
    - Record the previous behavior or pressure, the resulting behavior or
-     structure, the material impact boundary, the checks that actually ran,
-     and verified references.
+     structure, the material impact boundary, the behavior exercised by tests,
+     the checks that actually ran, and verified references.
+   - Keep tested behavior separate from execution evidence: `Tests` explains
+     coverage, while commands and pass or fail results belong in the execution
+     report.
    - Select the smallest useful fact for each message section; do not render
      every fact collected in the evidence card.
 6. Write and challenge the subject and body.
@@ -113,13 +128,16 @@ issue mapping, and use review or CI skills for review/CI failures.
    - If the subject only states a goal or quality, replace it with the actual
      rename, extraction, move, removal, behavior correction, or other staged
      action.
-   - Keep long identifiers in `What` only when they materially improve
-     recognition; do not coin compressed domain terms to fit them in the
-     subject.
+   - Omit internal fields, files, helper names, and call-site counts that the
+     diff already shows. Keep an identifier only when it materially improves
+     recognition under the language rule.
    - Render the exact section order: `Why`, `What`, `Impact`, `Tests`, `Refs`.
    - Give each section one job: reason, change, effect, proof, or reference.
      Do not repeat tests, call-site counts, assertions, or state tables across
      sections.
+   - In `Tests`, name the behavior or boundary covered. Add the expected result
+     or prevented failure when that is the important regression signal. Do not
+     write a command, `PASS`, or "added a test" there.
    - Make the sections read as one chain: previous problem -> implemented
      change -> observable result or preserved boundary -> proof -> reference.
 7. Execute the selected path.
@@ -148,8 +166,9 @@ issue mapping, and use review or CI skills for review/CI failures.
 - If a precise identifier makes the subject long or hard to read, use the
   established project noun in the subject and leave the identifier to `What`
   or the diff.
-- If a test fact appears in `Why`, `What`, or `Impact`, move it to `Tests`
-  unless the test itself is the primary change.
+- If a test fact appears in `Why`, `What`, or `Impact`, move the covered
+  behavior to `Tests` unless the test itself is the primary change. Keep the
+  command and result in the execution report.
 - If call-site counts or individual assertions do not change the reader's
   understanding, omit them.
 - If the reason or impact cannot be supported, state the narrow verified
@@ -174,7 +193,10 @@ issue mapping, and use review or CI skills for review/CI failures.
 | "Every discovered fact should appear in the body." | The evidence card is an input filter, not an output checklist. Keep only what a future reader needs. |
 | "The diff is large but it is easier to review as one commit." | Large mixed commits hide intent and rollback boundaries; split unless the change is one inseparable unit. |
 | "Tests are already in the execution report." | The repository requires durable verification evidence in the single Tests section. |
-| "I can add another Tests section for the second command." | The body has one Tests section with multiple bullets. |
+| "I can add another Tests section for the second command." | Commands stay in the execution report. The body has one Tests section for covered behavior. |
+| "Tests should list the command that passed." | Commands prove execution elsewhere. Commit prose should state the behavior covered and the result when it matters. |
+| "Tests should say that I added regression coverage." | That narrates the test diff. Name the behavior or boundary the coverage protects. |
+| "Internal names make every section more concrete." | Internal inventory is already visible in the diff. Keep only names that carry contract or state-transition meaning. |
 
 ## Red Flags
 
@@ -201,6 +223,10 @@ issue mapping, and use review or CI skills for review/CI failures.
   changes are bundled together for speed.
 - Tests are marked as "not requested" instead of giving a real operational
   reason.
+- `Tests` lists commands, `PASS`, test file names, or "added coverage" without
+  naming the behavior or boundary exercised.
+- Internal fields, helpers, paths, or call-site counts appear without explaining
+  their behavior-level significance.
 
 ## Verification
 
@@ -217,6 +243,11 @@ issue mapping, and use review or CI skills for review/CI failures.
 - [ ] Every claim is grounded in the request, issue, staged diff, or tests.
 - [ ] Each supporting detail appears in only one owning section, with one
       bullet per section unless a second independent fact is necessary.
+- [ ] `Tests` states the behavior or boundary exercised and includes the
+      expected result when it is material; commands and results stay in the
+      execution report.
+- [ ] Internal identifiers appear only when they carry public contract,
+      change-object, or state-transition meaning.
 - [ ] Traceability is verified through `issue-gate-skill`, repository evidence,
       explicit user input, or `Refs: - n/a`.
 - [ ] Required pre-commit hygiene checks from
@@ -272,6 +303,8 @@ issue mapping, and use review or CI skills for review/CI failures.
   signals.
 - Do not use `"not requested"` as the explanation for missing tests; use a real
   operational reason.
+- Do not put routine commands, `PASS` markers, or test-file inventory in the
+  commit message; report them after execution.
 - Do not require an AI session identifier unless the repository explicitly
   requires it.
 - Do not amend, rebase, or force-push unless the user explicitly asks.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Commit"
-  short_description: "v0.2.4 - Execute concise, traceable Git commits"
-  default_prompt: "Use $git-commit-skill to inspect the staged evidence, split by size and concern, verify traceability, and execute each save-point commit with the shortest concrete subject plus one focused bullet in each required Why/What/Impact/Tests/Refs section."
+  short_description: "v0.2.5 - Execute behavior-first, traceable Git commits"
+  default_prompt: "Use $git-commit-skill to inspect staged evidence and recent repository language, split by concern, verify traceability, and execute each save-point commit with one distinct behavior fact in every required Why/What/Impact/Tests/Refs section while keeping command results in the execution report."

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
@@ -169,7 +169,9 @@ Before every executed commit:
    `git diff --cached --name-status`.
 2. Check the staged diff for obvious secrets or credentials.
 3. Run the most relevant tests or checks for the staged change.
-4. If tests/checks are not run, record a real operational reason in `Tests`.
+4. If tests/checks are not run, record the operational reason in the execution
+   report and state the unverified behavior boundary honestly in `Tests`; do
+   not invent a passing result.
 5. Confirm generated files, lockfiles, snapshots, and schema outputs are
    expected by the repository before including them.
 
@@ -194,7 +196,8 @@ For each commit slice:
 2. Confirm the slice is one logical change and satisfies the size guidance.
 3. Stage only those files.
 4. Run pre-commit hygiene.
-5. Write the final commit message using `commit-message-standard.md`.
+5. Write the final commit message using `commit-message-standard.md`; keep
+   routine commands and pass or fail results in the execution report.
 6. Run `git commit -F <file>`.
 7. Report commit hash, staged scope, tests, `Refs`, and remaining unstaged
    scope.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
@@ -46,9 +46,16 @@ primary_object: <behavior, symbol, document, contract, or state transition>
 before: <specific previous behavior, ambiguity, failure, or request>
 after: <specific resulting behavior or structure>
 impact_boundary: <observable effect or behavior explicitly preserved>
-tests: <commands or checks that actually ran, with results>
+testing_boundary:
+  coverage: <behavior, scenario, or boundary exercised>
+  expected: <result observed or asserted, when material>
+  prevented: <incorrect behavior that did not occur, when material>
+execution_checks: <commands that ran, results, or skipped-check reason>
 refs: <verified issue/spec/incident/PR, or n/a when allowed>
 ```
+
+`testing_boundary` supplies `Tests`. `execution_checks` belongs in CI or the
+execution report. Do not turn it into `PASS: <command>` commit prose.
 
 Use these sources in this order:
 
@@ -57,7 +64,9 @@ Use these sources in this order:
 2. The issue or user request supplies the trigger and intended outcome.
 3. Tests establish verified behavior; they do not justify claims they do not
    exercise.
-4. Repository conventions determine type, scope, and reference syntax.
+4. Recent repository history supplies concrete verbs, behavior phrasing, and
+   project vocabulary when those patterns are consistent.
+5. Repository conventions determine type, scope, and reference syntax.
 
 Do not draft the subject until `primary_action` and `primary_object` are both
 known. Inspect the diff again when either field would otherwise contain an
@@ -67,9 +76,11 @@ After gathering evidence, select only what a future reader needs. Evidence can
 remain unrendered when the diff already carries it and omitting it does not
 make the message ambiguous.
 
-Use real identifiers and state values only when they improve recognition. Long
-identifiers belong in `What` or may stay in the diff when a familiar project
-noun is sufficient. Never invent a symbol name that is not in the staged diff.
+Default to omitting internal fields, files, helper names, call-site counts, and
+private types because the diff already records them. Keep an identifier only
+when it is a public contract, the direct object of a rename or move, or needed
+to distinguish a state transition such as `error` to `completed`. Never invent
+a symbol name that is not in the staged diff.
 
 ## Commit Message Format
 
@@ -95,9 +106,10 @@ Refs:
 ```
 
 This structure is mandatory. Do not add, omit, rename, or duplicate sections.
-When several checks ran, list them as separate bullets under the single
-`Tests` section. Use one bullet with one sentence in every section by default.
-Add another bullet only for a separate fact required to understand the commit.
+When several independent behavior boundaries were tested, list them as
+separate bullets under the single `Tests` section. Use one bullet with one
+sentence in every section by default. Add another bullet only for a separate
+fact required to understand the commit.
 
 ## Subject Rules
 
@@ -147,8 +159,9 @@ Assign each fact to one location before writing:
 | `Why` | one previous problem or trigger | test motivation, future speculation, solution details |
 | `What` | one resulting code, behavior, or document change | call-site counts, assertion lists, impact claims |
 | `Impact` | one observable effect or preserved boundary | repeated state tables, implementation details |
-| `Tests` | checks that ran and their result | why the production change was needed |
+| `Tests` | covered behavior or boundary and material expected result | commands, pass markers, test-file inventory |
 | `Refs` | verified traceability | extra explanation |
+| Execution report | commands, pass or fail results, skipped checks | behavior rationale |
 
 State each supporting detail once. Repeat the core behavior only when needed to
 connect `Why`, `What`, and `Impact`; do not repeat call-site counts, full state
@@ -164,6 +177,8 @@ Write natural project language:
   but less natural technical label.
 - Do not hard-wrap inside an identifier. Wrap surrounding prose or omit a long
   identifier when the established project noun is sufficient.
+- Use repository history to learn sentence style, not to copy its issue IDs,
+  generated trailers, internal names, or section layout.
 
 ## Body Quality Bar
 
@@ -180,8 +195,9 @@ Write natural project language:
 ### What
 
 - State the resulting behavior or structural change.
-- Use real function names, state values, or contract terms when they make the
-  change verifiable and easier to locate.
+- Describe the resulting behavior before implementation mechanics. Use a real
+  function name, state value, or contract term only when it carries meaning
+  under the internal-detail rule.
 - When both rename identifiers are long, name only the new identifier; the diff
   already records the old one.
 - Every bullet must be supported by the staged diff or tests.
@@ -204,14 +220,15 @@ Write natural project language:
 
 ### Tests
 
-- State what actually ran and whether it passed.
-- Put every test, compile command, lint command, manual check, or skipped-test
-  reason under the single `Tests` section.
-- If tests did not run, use a real reason such as:
-  - `not run (docs-only change)`
-  - `not run (config-only change)`
-  - `not run (blocked: <reason>)`
-- Do not use `not requested`.
+- State the behavior, scenario, or boundary covered.
+- Use a compact coverage list when `What` already makes the expected result
+  clear, such as "cover safe and ambiguous path forms." Add the expected result
+  when the prevented regression is the important fact.
+- Do not list commands, `PASS`, test file names, or "added a regression test."
+  Those describe execution or the diff, not the behavior protected.
+- If behavior verification did not run, state the unverified boundary and real
+  reason honestly; keep command-level details in the execution report.
+- Do not claim that one test guarantees behavior beyond its exercised scenario.
 
 ### Refs
 
@@ -267,7 +284,7 @@ Impact:
 - 缓存恢复和响应检查行为不变。
 
 Tests:
-- PASS: pytest tests/test_response_check.py -k empty_matrix_cache
+- 空矩阵缓存仍恢复为 completed，缓存缺失仍返回 None。
 
 Refs:
 - ISSUE: #168
@@ -291,7 +308,7 @@ Impact:
 - 命中空矩阵缓存的任务不再被错误标记为抽取失败。
 
 Tests:
-- PASS: pytest tests/test_response_check.py -k empty_matrix_cache
+- 空矩阵缓存恢复为 completed，不再进入抽取失败结果。
 
 Refs:
 - ISSUE: #168
@@ -312,11 +329,86 @@ Impact:
 - 读者可以仅按入门文档完成本地配置；运行时代码不变。
 
 Tests:
-- PASS: markdownlint docs/onboarding.md
+- 环境变量表同时包含 CACHE_URL 的用途、示例值和启动所需说明。
 
 Refs:
 - n/a
 ```
+
+### Repository-Language Contrasts
+
+The following scenarios are sanitized from recurring language patterns in a
+mature repository history. They teach wording only; this skill keeps its own
+required five-section structure.
+
+| Section | Avoid | Prefer |
+|---|---|---|
+| `Why` | `The metadata sources need better consistency.` | `A saved working directory can become stale after thread metadata changes, so reads and lists report different locations.` |
+| `What` | `Update the state overlay and recompute internal metadata.` | `Prefer the persisted working directory when it belongs to the requested thread, while retaining the saved fallback for older records.` |
+| `Impact` | `This improves thread reliability.` | `Thread reads and lists now agree on the saved location; older records without one keep their previous behavior.` |
+| `Tests` | `PASS: cargo test -p core thread_read` | `Stale and empty saved locations select the expected value, while a resumed thread still uses its requested live location.` |
+| `Tests` | `Add regression coverage for path handling.` | `Cover safe and ambiguous path forms, encoded traversal, and hosts that require inspection.` |
+
+The two preferred `Tests` forms are both valid:
+
+- `Cover ...` names a compact behavior boundary when the expected result is
+  already clear from `What`.
+- A full behavior assertion names the result when that result is the regression
+  future readers need to retain.
+
+### Complete Behavior-First Example
+
+```text
+fix(proxy): reject ambiguous paths before authorization
+
+Why:
+- Authorization runs before upstream parsing, so a path that normalizes to
+  another resource could match the wrong allowlist entry.
+
+What:
+- Reject traversal, malformed encoding, and encoded separators before matching
+  the request against allowed paths.
+
+Impact:
+- An allowed path cannot be reinterpreted as another resource; ordinary safe
+  paths keep their previous behavior.
+
+Tests:
+- Safe paths remain allowed, while ambiguous paths are rejected before they can
+  reach another resource.
+
+Refs:
+- ISSUE: #123
+```
+
+This message uses internal concepts only where they explain the authorization
+boundary. Parser helpers, changed files, assertions, and commands stay in the
+diff or execution report.
+
+### Overloaded Version of the Same Change
+
+```text
+fix(proxy): harden authorization consistency
+
+Why:
+- Path validation needed to be more robust.
+
+What:
+- Update parse_hook_path, normalize_percent_encoding, and three proxy callers.
+
+Impact:
+- Authorization is safer and more reliable.
+
+Tests:
+- PASS: cargo test -p network-proxy authorization
+
+Refs:
+- ISSUE: #123
+```
+
+The subject states a quality, `Why` is generic, `What` narrates the diff,
+`Impact` is unsupported, and `Tests` is an execution log. The structure is
+complete, but the behavior transition is still unclear.
 
 ## Anti-Patterns
 
@@ -336,9 +428,11 @@ For the behavior-preserving rename example, reject this overloaded body shape:
 
 | Section | Avoid | Prefer |
 |---|---|---|
-| `Why` | `空矩阵也是有效缓存结果，需要用测试固定其完成态边界，避免后续重新引入失败状态判断。` | Omit it; test motivation and speculative regressions do not explain the production rename. |
+| `Why` | `空矩阵也是有效缓存结果，需要用测试固定其完成态边界，避免后续重新引入失败状态判断。` | `原名称暗示会恢复所有抽取状态，实际只处理 completed 缓存结果。` |
 | `What` | `同步两处工作流调用，并验证 completed、100% 且无错误。` | State the rename once; report the check under `Tests`. |
 | `Impact` | `成功和空矩阵返回 completed，缺失缓存返回 None；运行时抽取失败仍写入 error。` | `缓存恢复和响应检查行为不变。` |
+| `Tests` | `PASS: pytest ...` | `空矩阵缓存仍恢复为 completed，缓存缺失仍返回 None。` |
+| `Tests` | `增加空矩阵回归测试。` | `空矩阵缓存恢复为 completed，不再进入抽取失败结果。` |
 
 ## Verification
 
@@ -352,12 +446,16 @@ Before accepting a message, confirm:
 - [ ] `Why` names the previous problem or trigger.
 - [ ] `What` names the actual behavior or structural change.
 - [ ] `Impact` names an observable result or precisely preserved boundary.
-- [ ] `Tests` reports every relevant check that actually ran, or a real
-      operational reason for not running it.
+- [ ] `Tests` states the behavior or boundary covered and includes the expected
+      result when it is material, or honestly states the unverified boundary.
+- [ ] Commands, pass or fail results, and skipped-check details stay in the
+      execution report rather than the commit message.
 - [ ] `Refs` contains only verified traceability or an allowed `n/a` fallback.
 - [ ] `Why -> What -> Impact` reads as one causal chain.
 - [ ] Each supporting detail appears in its owning location only.
 - [ ] Every section has one bullet unless another independent fact is required.
 - [ ] The message uses established project terms and no coined noun stack.
+- [ ] Internal identifiers appear only when they carry public contract,
+      change-object, or state-transition meaning.
 - [ ] No generic benefit, vague intent phrase, invented identifier, or
       unsupported impact remains.

--- a/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-gate-skill
-description: v0.1.22 - Check, draft, create, and link GitHub or GitLab issues for tracked work. Use when turning approved workflow-plan tasks into mapped issue-backed acceptance work items, confirming canonical issue traceability before implementation or commit preparation, targeting canonical repos, or producing commit Refs output.
+description: v0.1.23 - Check, draft, create, and link concise GitHub or GitLab issues for tracked work. Use when turning approved workflow-plan tasks into mapped issue-backed acceptance work items, confirming canonical issue traceability before implementation or commit preparation, targeting canonical repos, or producing commit Refs output.
 ---
 
 # Issue Gate Skill
@@ -9,8 +9,9 @@ description: v0.1.22 - Check, draft, create, and link GitHub or GitLab issues fo
 
 Keep meaningful tracked work connected to the canonical issue that explains
 purpose, scope, acceptance, and commit traceability. This skill checks whether
-the right GitHub or GitLab issue already exists, drafts a master-grade issue
-when it is missing, maps approved workflow-plan tasks into issue-backed
+the right GitHub or GitLab issue already exists, drafts the shortest
+decision-ready issue when it is missing, maps approved workflow-plan tasks into
+issue-backed
 acceptance units, and emits the deterministic `Refs` bridge used by
 `git-commit-skill`.
 
@@ -59,6 +60,8 @@ In scope:
   advances, investigates, or partially implements the work.
 - Keep commit flow human-controlled with automation guardrails.
 - Provide a deterministic bridge from issue lifecycle to commit metadata.
+- Render only facts needed to understand, bound, and accept the work; keep gate
+  administration out of the issue body.
 
 ## Bundled Resources
 
@@ -133,7 +136,10 @@ One of:
 - `create_policy=parent-first-child-second-confirmed`
 - `audience_profile=cross_functional`
 - `issue_level=parent_requirement`
-- `quality_bar=master_grade`
+- `quality_bar=decision_ready`
+- `content_selection=shortest_complete`
+- `optional_section_policy=omit_empty`
+- `section_density=one_to_three_facts_by_default`
 - `implementation_detail_mode=defer-unless-explicitly-requested`
 - `plan_handoff_mode=issue-ready-tasks-only`
 - `task_issue_policy=group-by-independent-delivery-slice`
@@ -266,6 +272,12 @@ One of:
   prefix before creating an issue.
 - Do not block reuse of an existing issue solely because its title lacks a
   recognized prefix. Reuse it and emit a `title_prefix_warning` instead.
+- The short title must name the concrete problem, outcome, or action and its
+  recognizable object; the prefix alone does not make a title useful.
+- For bugs, prefer the failing condition and incorrect result. For features,
+  tasks, and maintenance work, prefer a concrete action or delivered outcome.
+- Reject broad quality summaries such as "improve workflow clarity", "optimize
+  handling", "align behavior", or equivalent vague wording.
 
 ## Platform Selection
 
@@ -325,11 +337,19 @@ surface, remote-detection commands, or automation caveats.
   - `issue_level`: default `parent_requirement`; upgrade to `delivery_task` or
     `implementation_task` only when scope is execution-ready or the operator
     explicitly wants technical breakdown
-  - `quality_bar`: default `master_grade`; optimize for decision quality,
-    traceability, and execution clarity before optimizing for length
-- Default auto-drafts must be decision-ready first: enough context to justify
-  the work, enough scope to bound it, and enough acceptance detail to test it.
-  Brevity is secondary unless the operator explicitly asks for compression.
+  - `quality_bar`: default `decision_ready`; optimize for the shortest body
+    that still supports scope and acceptance decisions
+- Build a content card before drafting: concrete problem, target outcome,
+  in-scope work, out-of-scope boundary, observable acceptance, verification,
+  and only material risks or dependencies.
+- Select the smallest useful fact set from that card. Do not render every fact
+  merely because it was inferred.
+- Default auto-drafts must be shortest-complete: enough context to justify the
+  work, enough scope to bound it, and enough acceptance detail to test it.
+- Render each supporting fact once in its owning section. Repeat a core noun
+  only when needed to connect the problem, outcome, and acceptance.
+- Omit optional sections and fields when no supported fact exists. Never add
+  `n/a`, empty headings, or placeholder bullets to make a template look full.
 - Draft must respect template-required fields by the resolved
   `template_family` and `issue_level`.
 - Draft title must respect the Issue Title Prefix Rule. If an inferred or
@@ -342,10 +362,27 @@ surface, remote-detection commands, or automation caveats.
 - If the generated draft reads like a design doc, implementation plan, or
   speculative architecture proposal, rewrite it before presentation.
 
-## Master-Grade Issue Standard
+## Issue Content Ownership
 
-A master-grade issue is not defined by length. It is defined by decision
-quality. The draft should be:
+Assign each rendered fact before writing:
+
+- title: concrete problem, outcome, or action plus recognizable object
+- problem/background: current observable problem and why it matters now
+- target outcome: the state readers should see when the work succeeds
+- scope: included work and the one exclusion needed to prevent scope drift
+- acceptance: observable completion conditions, not implementation steps
+- verification: how completion will be checked, without repeating acceptance
+- risks/dependencies: only real blockers, coordination needs, or constraints
+- implementation detail: engineering child issue only when needed for action
+
+Administrative fields such as platform choice, template family, issue level,
+prefix source, missing-field warnings, creation order, and execution commands
+belong in the dry-run result, not in the issue body.
+
+## Decision-Ready Issue Standard
+
+A decision-ready issue is not defined by length or heading count. The draft
+should be:
 
 - clear on `why now`, not just `what to build`
 - scoped so readers know what is in and out
@@ -358,78 +395,29 @@ quality. The draft should be:
   completion
 - solution-aware but not solution-locked unless implementation detail is
   already approved and necessary
+- compact by default: typical maintenance tasks use four core sections, while
+  complex bugs or cross-functional features expand only for real evidence
 
-## Issue Layering Rule
+## Issue Layering Decision
 
-- Default parent issues to product-, outcome-, and scope-oriented framing.
-- A `parent_requirement` should be readable by PM, product, and cross-functional
-  stakeholders without requiring knowledge of the internal codebase.
-- Parent issues should focus on:
-  - background or problem
-  - target outcome
-  - scope boundary
-  - external contract or user impact
-  - acceptance criteria
-  - risks or dependencies
-- Parent issues should not default to:
-  - code snippets
-  - file paths
-  - class, function, or method names
-  - internal module splits
-  - planner, repo, service, Cypher, schema, table, or similar
-    implementation-facing nouns
-- The only technical detail that may remain in a parent issue by default is
-  external contract information that stakeholders need to reason about, such as
-  a user-facing API contract, compatibility note, or externally visible input /
-  output behavior.
-- If the draft needs detailed implementation paths, migration sequencing,
-  architecture comparisons, or component-by-component responsibilities, keep
-  the parent issue lean and split those details into a linked engineering child
-  issue, `delivery_task`, or `implementation_task`.
-
-## Child Issue Decision Rule
-
-- Default `child_issue_needed=no`.
-- Set `child_issue_needed=yes` when the parent issue would otherwise need:
-  - implementation paths or migration sequencing
-  - architecture comparisons or option tradeoff analysis
-  - module-by-module responsibilities
-  - engineering-only validation or rollout steps
-  - internal nouns such as planner, repo, service, Cypher, schema, table,
-    worker, class, file, or function to preserve actionable meaning
-- If the engineering detail is execution-ready but still one level above code,
-  use `child_issue_type=delivery_task`.
-- If the engineering detail requires implementation-facing structure such as
-  internal contracts, dataflow, module breakdown, migration steps, or approved
-  design details, use `child_issue_type=implementation_task`.
-- If parent-issue overspecification can be fixed by rewriting without losing
-  necessary execution detail, keep `child_issue_needed=no`.
-- If rewriting would hide necessary engineering work, keep the parent issue
-  product-facing and auto-draft a linked child issue.
-- When `child_issue_needed=yes`, the dry-run output must include both parent and
-  child drafts before any create action.
-
-## Framing Guardrails
-
-- `parent_requirement`: explain why the work matters, what outcome is expected,
-  what is in or out of scope, how success is judged, and what external contract
-  or user impact matters.
-- `parent_requirement`: do not include code blocks, file paths, function names,
-  class names, internal dataflow, or module-by-module implementation plans
-  unless that information is itself part of an approved external contract.
-- `delivery_task`: may mention affected modules or contracts, but should still
-  optimize for shared understanding over internal implementation detail.
-- `implementation_task`: technical detail is allowed only when the operator
-  explicitly asks for an engineering-facing issue or when a design has already
-  been approved.
-- For leadership, PM, frontend, or mixed-audience issues, prefer
-  business/problem language over internal architecture nouns.
-- Do not lock parent issues to speculative classes, files, routes, tables,
-  workers, or module splits unless those details are already approved and
-  necessary for disambiguation.
-- When tightening a draft, remove repetition before removing decision-critical
-  context; never trade away problem clarity, scope clarity, or acceptance
-  clarity just to save lines.
+- Default `child_issue_needed=no` and keep `parent_requirement` readable by PM,
+  product, and cross-functional stakeholders.
+- Parent issues own the problem, outcome, scope, external contract when
+  material, and acceptance. They do not carry code snippets, file paths,
+  internal dataflow, module breakdowns, or speculative implementation names.
+- Rewrite an over-specified parent first. Set `child_issue_needed=yes` only
+  when removing internal detail would make necessary engineering work
+  unactionable.
+- Use `delivery_task` for an execution-ready slice that can stay
+  contract-oriented. Use `implementation_task` when approved internal
+  contracts, dataflow, migrations, or module responsibilities are required.
+- When a child is needed, show both drafts before creation and keep their
+  relationship explicit.
+- When `plan_task_handoff` maps any task to `child_issue` or
+  `grouped_child_issue`, draft that child set unless the operator explicitly
+  approves parent-only tracking.
+- Remove repetition before decision-critical context. Do not shorten away the
+  problem, scope boundary, or acceptance surface.
 
 ## Issue Template Resolution
 
@@ -453,19 +441,20 @@ If `change_type` is ambiguous:
 Read `references/issue-templates.md` when you need:
 
 - the full template bodies
-- template-specific required and recommended fields
+- template-specific required and conditional fields
 - template validation notes
 - standard create payload shapes for `gh` or `glab`
 
 ## Template Validation Rule
 
-- Resolve `template_family` and `issue_level` first.
-- Validate semantic required fields against the selected template family, not a
-  single fixed heading set.
-- Validate new issue titles against the Issue Title Prefix Rule.
-- Validate issue quality as well as field presence: clear problem statement,
-  explicit target outcome, bounded scope, testable acceptance, and
-  audience-appropriate detail.
+- Resolve `template_family` and `issue_level`, then validate the selected
+  canonical body from `references/issue-templates.md`.
+- Validate the title prefix and concrete short-title meaning, required semantic
+  fields, information ownership, acceptance, and audience fit.
+- Validate that the rendered body follows one canonical template for the
+  selected family; command examples must not introduce a second body schema.
+- Do not report an absent optional field as missing and do not render it as
+  `n/a`; only required fields can block creation.
 - If template-required fields are missing:
   - `gate_mode=required` => `BLOCK`
   - `gate_mode=recommended` => `PASS_WITH_WARNING`
@@ -484,22 +473,11 @@ Read `references/issue-templates.md` when you need:
   - `child_issue_needed`
   - `child_issue_type`
   - `missing_required_fields`
-  - `missing_recommended_fields`
   - `overspecification_warnings`
-- For `parent_requirement`, if the body contains code snippets, file paths,
-  class names, function names, implementation-phase jargon, or architecture
-  comparisons that are not required to explain an external contract, emit an
-  `overspecification_warning` and rewrite or split before presentation.
-- If a parent issue still needs engineering detail after rewrite, require
-  `child_issue_needed=yes` and draft a linked child issue instead of keeping
-  that detail in the parent body.
-- For backend-, AI-, workflow-, or integration-heavy feature work, missing
-  `技术约束` or `验证方式` should emit an explicit warning.
-- For investigation work, missing a concrete `预期产出` or
-  `退出条件 / 范围边界` must be treated as a required-field failure.
-- If a `parent_requirement` draft contains speculative classes, files, routes,
-  tables, workers, or unapproved architecture splits, emit an
-  `overspecification_warning` and rewrite before presentation.
+- Rewrite or split a parent when unnecessary code, file, module, schema,
+  sequencing, or architecture detail triggers `overspecification_warning`.
+- Treat a missing investigation deliverable or exit boundary as a required
+  field failure.
 
 ## The Operating Loop
 
@@ -534,9 +512,14 @@ Read `references/issue-templates.md` when you need:
      a new draft from context only when no matching issue exists
 6. Draft or verify issue content:
    - ensure new issue titles use the required `<prefix>: <short title>` format
+   - reject titles that state only a quality or intention without a concrete
+     problem, outcome, action, and object
+   - build the content card and assign each selected fact to one owning section
    - ensure the draft explains why now, what outcome is expected, what is in or
      out of scope, how success is judged, and whether any material dependency
      or risk must be named
+   - omit unsupported optional sections instead of rendering placeholders or
+     `n/a`
    - strip unapproved implementation details from parent issues unless the
      operator explicitly wants an implementation-facing task
    - if detailed engineering reasoning is needed, keep the parent issue
@@ -631,11 +614,15 @@ happy-path example of the full required flow.
 | "Workflow-plan tasks map directly to issues." | Plan tasks are source material. Group or split by independently reviewable, assignable, and verifiable delivery slices. |
 | "An existing issue without a prefix is invalid." | Reuse matching existing issues and emit a title-prefix warning; prefix enforcement applies to new drafts. |
 | "The issue link means this commit resolves the issue." | Default linkage is a reference bridge, not closure semantics. |
+| "A complete issue renders every template section." | Completeness means the necessary decision facts are present. Empty optional sections and `n/a` rows make the issue harder to read. |
+| "More background bullets make the issue clearer." | Keep one concrete problem statement and move distinct boundaries or acceptance facts to their owning sections. |
 
 ## Red Flags
 
 - A new issue title lacks `<prefix>: <short title>` and no repository override
   is documented.
+- A new title passes the prefix rule but uses vague wording such as "improve",
+  "align", "optimize", or "clarify" without a concrete object and outcome.
 - `Plan Task Issue Mapping` is missing when `workflow-plan` tasks were
   supplied.
 - A multi-task plan is parent-only without concrete per-task rationale.
@@ -650,6 +637,12 @@ happy-path example of the full required flow.
   the issue.
 - CLI availability is treated as platform proof without matching the resolved
   repository host.
+- The body renders optional headings, links, metrics, logs, risks, or rollback
+  fields as `n/a`.
+- The same problem, outcome, state table, or test detail appears in several
+  sections.
+- A routine maintenance issue expands beyond its core problem, scope,
+  acceptance, and verification without a material reason.
 
 ## Verification
 
@@ -662,11 +655,15 @@ happy-path example of the full required flow.
       duplicate.
 - [ ] New issue drafts apply the Issue Title Prefix Rule or block for prefix
       confirmation.
+- [ ] New titles name a concrete problem, outcome, or action and recognizable
+      object.
 - [ ] Template validation reports family, issue level, title prefix, missing
       fields, child issue decision, and overspecification warnings.
 - [ ] `Plan Task Issue Mapping` is emitted whenever plan tasks are supplied.
 - [ ] Parent and child issue drafts are shown in dry-run output before any
       create action.
+- [ ] Issue bodies use one canonical template, omit empty optional sections,
+      and keep each supporting fact in one owning section.
 - [ ] Commit bridge emits a verified `refs_line` and does not modify commit
       message content directly.
 - [ ] Gate result is `PASS`, `PASS_WITH_WARNING`, or `BLOCK` with an explicit
@@ -674,24 +671,29 @@ happy-path example of the full required flow.
 
 ## Output Format
 
+Render only the blocks relevant to the requested mode. `Gate Result` and
+`Target` are always present. Omit every other block when it has no artifact;
+within an included block, omit optional fields without values. Do not render
+blank fields or `n/a` placeholders.
+
 ```text
 ## Gate Result
 - gate_mode:
 - result: PASS | PASS_WITH_WARNING | BLOCK
 - reason:
 
-## Layering Decision
-- parent_issue_level: parent_requirement | delivery_task | implementation_task
-- child_issue_needed: yes | no
-- child_issue_type: delivery_task | implementation_task | n/a
-- child_issue_reason:
-- parent_rewrite_applied: yes | no
-
-## Platform
-- selected: gh | glab
+## Target
+- selected_platform: gh | glab
 - cli_ready:
 - target_repo:
 - search_scope: current_repo | upstream_repo | explicit_override
+
+## Layering Decision (draft/create modes only)
+- parent_issue_level: parent_requirement | delivery_task | implementation_task
+- child_issue_needed: yes | no
+- child_issue_type: delivery_task | implementation_task
+- child_issue_reason:
+- parent_rewrite_applied: yes | no
 
 ## Issue Action
 - action: reuse | create | failed
@@ -700,43 +702,43 @@ happy-path example of the full required flow.
 - issue_url:
 - title_source: user_input | auto_draft
 - title_prefix:
-- title_prefix_source: change_type | repo_policy | user_input | n/a
+- title_prefix_source: change_type | repo_policy | user_input
 - title_prefix_warnings:
 
-## Parent Issue Draft
+## Parent Issue Draft (create mode only)
 - title:
 - draft_preview:
 
-## Child Issue Draft
+## Child Issue Draft (only when child_issue_needed=yes)
 - title:
 - draft_preview:
 - link_to_parent:
 
-## Plan Task Issue Mapping
+## Plan Task Issue Mapping (only with plan_task_handoff)
 - task:
 - decision: parent_only | child_issue | grouped_child_issue
-- issue_level: parent_requirement | delivery_task | implementation_task | n/a
+- issue_level: parent_requirement | delivery_task | implementation_task
 - grouping_key:
 - acceptance_source:
 - rationale:
 - child_issue_title:
 
-## Draft Decision
+## Draft Decision (draft/create modes only)
 - audience_profile:
 - issue_level: parent_requirement | delivery_task | implementation_task
 - quality_pass: yes | no
 
-## Execution Plan
+## Execution Plan (create mode only)
 - create_parent: yes | no
 - create_child: yes | no
 - create_policy: parent-first-child-second-confirmed
 - link_method: body_reference | comment_reference
 
-## Commit Bridge
+## Commit Bridge (commit bridge mode only)
 - refs_line: ISSUE: #<id>
 - next_for_commit_skill:
 
-## Execution Trace
+## Execution Trace (only after commands execute)
 - dry_run_plan:
 - executed_commands:
 - timestamp:
@@ -770,7 +772,10 @@ happy-path example of the full required flow.
 - Do not wrap issue references in backticks when the output is meant to keep
   clickable issue links.
 - Do not treat issue linkage as issue resolution by default.
-- Default to master-grade standard drafts.
+- Default to shortest-complete, decision-ready drafts.
+- Do not expose gate administration as issue-body headings.
+- Do not render empty optional sections or `n/a` filler in issue bodies or
+  mode-irrelevant output blocks.
 - Do not turn a parent requirement issue into a design doc or implementation
   plan.
 - Do not default parent issues to code, file, class, function, planner, repo,

--- a/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Issue Gate"
-  short_description: "v0.1.22 - Map planned work into traceable acceptance issues"
-  default_prompt: "Use $issue-gate-skill to map approved workflow-plan tasks into issue-backed acceptance work items, emit a Plan Task Issue Mapping before deciding parent-only versus child issues, confirm or create the canonical issue for this tracked change, and produce the commit Refs bridge before commit preparation."
+  short_description: "v0.1.23 - Draft concise, traceable acceptance issues"
+  default_prompt: "Use $issue-gate-skill to find or draft the canonical issue, select the shortest decision-ready fact set, omit empty optional sections, map plan tasks only when supplied, confirm before creation, and emit the commit Refs bridge when requested."

--- a/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/references/issue-cli-reference.md
+++ b/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/references/issue-cli-reference.md
@@ -15,11 +15,11 @@ gh issue list -R <owner>/<repo> --state open --search "<keyword>" --limit 20
 # view a single issue with stable JSON fields
 gh issue view <issue_number> --json number,title,state,url
 
-# create issue in current repo
-gh issue create --title "<title>" --body "<body>" --label "<label>"
+# create issue in current repo from the canonical rendered body
+gh issue create --title "<title>" --body-file <body-file> --label "<label>"
 
-# create issue in an explicit repo
-gh issue create -R <owner>/<repo> --title "<title>" --body "<body>" --label "<label>"
+# create issue in an explicit repo from the same body
+gh issue create -R <owner>/<repo> --title "<title>" --body-file <body-file> --label "<label>"
 
 # add comment for commit or branch linkage
 gh issue comment <issue_number> --body "Linked commit: <sha>"
@@ -40,11 +40,11 @@ glab issue view <issue_number>
 # view a single issue in an explicit repo
 glab issue view <issue_number> -R <group>/<repo>
 
-# create issue in current repo
-glab issue create --title "<title>" --description "<body>" --label "<label>"
+# create issue in current repo from the canonical rendered body
+glab issue create --title "<title>" --description "$(cat <body-file>)" --label "<label>"
 
-# create issue in an explicit repo
-glab issue create -R <group>/<repo> --title "<title>" --description "<body>" --label "<label>"
+# create issue in an explicit repo from the same body
+glab issue create -R <group>/<repo> --title "<title>" --description "$(cat <body-file>)" --label "<label>"
 
 # add comment for commit or branch linkage
 glab issue note <issue_number> -m "Linked commit: <sha>"

--- a/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/references/issue-templates.md
+++ b/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/references/issue-templates.md
@@ -1,37 +1,50 @@
 # Issue Templates
 
-Use this reference when resolving `template_family`, drafting the issue body,
+Use this reference when resolving a template family, drafting an issue body,
 or validating template-specific required fields.
 
 ## Table of Contents
 
-- [Template Style Rule](#template-style-rule)
-- [Bug / Incident Template](#bug--incident-template)
-- [Feature / Change Template](#feature--change-template)
+- [Rendering Contract](#rendering-contract)
+- [Issue Title Rule](#issue-title-rule)
+- [Information Ownership](#information-ownership)
+- [Bug or Incident Template](#bug-or-incident-template)
+- [Feature or Change Template](#feature-or-change-template)
 - [Engineering Child Issue Template](#engineering-child-issue-template)
-- [Task / Maintenance Template](#task--maintenance-template)
-- [Investigation / Spike Template](#investigation--spike-template)
-- [Issue Title Prefix Rule](#issue-title-prefix-rule)
-- [Template Validation Rule](#template-validation-rule)
-- [Template-to-Command Mapping Examples](#template-to-command-mapping-examples)
-- [Existing Issue => link for commit](#existing-issue--link-for-commit)
+- [Task or Maintenance Template](#task-or-maintenance-template)
+- [Investigation or Spike Template](#investigation-or-spike-template)
+- [Examples](#examples)
+- [Anti-Patterns](#anti-patterns)
+- [Template Validation](#template-validation)
+- [Template-to-Command Mapping](#template-to-command-mapping)
 
-## Template Style Rule
+## Rendering Contract
 
-- Prefer clean section headings without `（必填）` or `（可选）` in the rendered
-  issue body.
-- Keep requiredness in skill validation rules and repository templates, not in
-  user-facing heading text.
-- When a repository already provides canonical issue templates, mirror their
-  field names and heading structure unless there is a strong reason not to.
-- When referencing related issues in rendered markdown, use plain `#123`,
-  `owner/repo#123`, or a full URL in normal prose; do not wrap the issue
-  reference itself in backticks if the link should stay clickable.
+These templates are fallback body contracts. A repository-provided canonical
+template overrides them when its required fields are explicit.
 
-## Issue Title Prefix Rule
+- Select exactly one template family and render one body schema.
+- Render required sections and only those optional sections backed by facts.
+- Omit empty optional headings, placeholder bullets, and `n/a` rows.
+- Use one short paragraph or one to three facts per section by default.
+- Expand only when another fact changes scope, acceptance, risk, or a decision.
+- Keep internal gate fields, CLI commands, prefix sources, and warnings outside
+  the issue body.
+- Use plain headings. Requiredness belongs in validation, not visible labels or
+  decorative heading markers.
+- Follow the user's language or the repository's established issue language;
+  localize headings consistently without changing their semantic ownership.
+- Square brackets around an optional template block mark a drafting condition;
+  never copy the brackets into a rendered issue.
+- Use issue references such as #123 or owner/repo#123 as plain Markdown text so
+  they remain clickable.
 
-New issue titles must use `<prefix>: <short title>`. Resolve `prefix` from
-`change_type` before selecting the create command:
+Completeness means that another person can understand, bound, and accept the
+work. It does not mean rendering every field the agent inferred.
+
+## Issue Title Rule
+
+New titles use `<prefix>: <short title>`. Resolve the prefix from `change_type`:
 
 - `feat|integration|workflow|api` => `feat`
 - `fix|bugfix|incident` => `bugfix`
@@ -44,656 +57,378 @@ New issue titles must use `<prefix>: <short title>`. Resolve `prefix` from
 - `chore` => `chore`
 - `spike|research|proposal|investigation` => `proposal`
 
-Existing issue titles without this prefix should warn, not block reuse.
+The short title must carry meaning after the prefix is removed:
 
-## Bug / Incident Template
+- bugs: name the failing condition and incorrect result
+- features: name the capability or observable outcome being added
+- tasks and maintenance: name the concrete action and recognizable object
+- investigations: name the decision or uncertainty to resolve
 
-Required fields:
-- `问题概述`
-- `复现步骤`
-- `预期结果`
-- `实际结果`
+Prefer established repository language. Do not coin compressed domain labels
+or use quality-only summaries such as "improve consistency", "clarify
+workflow", "optimize handling", or "align behavior".
 
-Recommended fields:
-- `影响范围 / 严重程度`
-- `修复验收`
+Examples:
 
-Optional fields:
-- `日志`
-- `截图`
-- `环境信息（浏览器 / OS / 后端版本 / 模型版本等）`
-- `输入样例 / 文件类型 / 任务 ID`
+| Evidence | Avoid | Prefer |
+|---|---|---|
+| Non-trivial builds can skip a code-local skeleton. | `docs: improve workflow clarity` | `docs: require code-local skeletons before non-trivial builds` |
+| Tutorial checkpoints can proceed after self-review. | `bugfix: fix tutorial consistency` | `bugfix: require independent review before tutorial checkpoint commits` |
+| Empty extraction results pass validation. | `bugfix: align extraction status` | `bugfix: reject empty extraction results` |
 
-Template:
+Existing issues without a recognized prefix may still be reused. Emit a
+warning instead of creating a duplicate.
 
-```text
-## 🐛 问题概述
-...
+## Information Ownership
 
-## 🔁 复现步骤
-1. ...
-2. ...
-3. ...
+Assign each fact before rendering:
 
-## ✅ 预期结果
-...
+| Section | Owns | Does not own |
+|---|---|---|
+| Problem or Background | current behavior, trigger, and why it matters | solution steps, acceptance checklist |
+| Outcome | externally visible or decision-relevant success state | implementation plan |
+| Scope | included work and meaningful exclusions | repeated problem statement |
+| Expected and Actual | observed behavioral contrast | speculative root cause |
+| Acceptance or Done | observable completion conditions | file-by-file edits or test commands |
+| Verification | commands, checks, or review method | another copy of acceptance |
+| Risks or Dependencies | real blockers, constraints, or coordination | generic cautions |
+| Evidence | logs, screenshots, IDs, or links that exist | empty attachment slots |
 
-## ❌ 实际结果
-...
+State each supporting fact once. Repeat the core behavior only when necessary
+to connect the problem, expected outcome, and acceptance criteria.
 
-## 🎯 影响范围 / 严重程度
-- 影响范围：...
-- 严重程度：...
-- 是否可绕过：...
+## Bug or Incident Template
 
-## 🧪 修复验收
-- 修复完成的判断标准：...
-- 需要回归的场景：...
+Required semantic fields:
 
-## 📎 其他信息
-- 日志：...
-- 截图：...
-- 环境信息：...
-- 输入样例 / 文件类型 / 任务 ID：...
-```
+- problem
+- reproduction steps or triggering condition
+- expected result
+- actual result
+- fix acceptance
 
-## Feature / Change Template
+Optional sections, rendered only with evidence:
 
-Required fields:
-- `背景 / 问题`
-- `目标 / 期望结果`
-- `范围边界`
-- `外部契约或用户影响`
-- `验收标准`
+- impact and severity
+- evidence such as logs, screenshots, environment, or sample IDs
+- regression scope when it adds more than the acceptance criteria
 
-Recommended fields:
-- `风险 / 依赖`
-- `验证方式`
-
-Optional fields:
-- `兼容性说明`
-- `接口文档`
-- `设计稿`
-- `关联 Issue / 需求编号`
-
-Standard template:
+Canonical body:
 
 ```text
-## 🧩 背景 / 场景
-- 为什么现在要做：...
-- 当前主要问题：...
-- 如果不做会带来什么影响：...
+## Problem
+<what fails, under which condition, and who or what is affected>
 
-## 🎯 目标 / 期望结果
-- 这次希望达成什么结果：...
-- 完成后外部应该看到什么变化：...
+## Reproduction
+1. <first necessary step>
+2. <second necessary step>
+3. <observed failure>
 
-## 🎯 范围边界
-- 本次要做：...
-- 本次不做：...
+## Expected
+<expected behavior>
 
-## 🌐 外部契约或用户影响
-- 用户侧 / 调用方会感知到什么变化：...
-- 是否涉及对外接口、输入输出、兼容性要求：...
-- 如果需要提接口，只描述外部行为，不展开内部实现：...
+## Actual
+<observed behavior>
 
-## ✅ 验收标准
-- [ ] ...
-- [ ] ...
+## Acceptance
+- [ ] <observable corrected behavior>
+- [ ] <material regression boundary, when needed>
 
-## ⚠️ 风险 / 依赖
-- 依赖项：...
-- 风险点：...
-- 需要协调或确认的事项：...
+[## Impact]
+<only when severity, affected users, or workaround is known>
 
-## 🧪 验证方式
-- 手工验证：...
-- 自动化测试：...
-
-## 📎 其他信息
-- 兼容性说明：...
-- 接口文档：...
-- 设计稿：...
-- 关联 Issue / 需求编号：...
+[## Evidence]
+<only existing logs, links, environment facts, or sample identifiers>
 ```
 
-Parent issue default rules:
+Do not invent reproduction steps for a non-reproducible incident. Use a
+concrete triggering condition and available evidence instead, and rename the
+section to `Trigger` when that is more accurate.
 
-- Default this template to `parent_requirement` and `cross_functional` unless
-  the operator explicitly requests an engineering-facing issue.
-- Do not include code blocks, file paths, class names, function names, module
-  splits, or internal architecture comparison by default.
-- If detailed implementation discussion is required, create a linked
-  engineering child issue instead of expanding the parent body.
+## Feature or Change Template
+
+Required semantic fields:
+
+- problem or opportunity
+- target outcome
+- scope boundary
+- acceptance criteria
+
+Optional sections, rendered only when material:
+
+- external contract or user impact
+- dependencies or risks
+- verification method
+
+Canonical body:
+
+```text
+## Problem
+<current limitation and why it matters now>
+
+## Outcome
+<capability or observable result this work should deliver>
+
+## Scope
+- Include: <included delivery boundary>
+- Exclude: <one exclusion needed to prevent scope drift>
+
+## Acceptance
+- [ ] <observable success condition>
+- [ ] <second independent success condition, when needed>
+
+[## External Contract]
+<only externally visible input, output, compatibility, or migration behavior>
+
+[## Dependencies]
+<only real dependencies, risks, or coordination requirements>
+
+[## Verification]
+<only when the verification method adds information beyond acceptance>
+```
+
+Keep parent feature issues outcome-facing. Move internal modules, files,
+schemas, migration steps, and implementation sequencing to an engineering
+child issue when they are needed for execution.
 
 ## Engineering Child Issue Template
 
-Use this template when the parent issue must stay product-facing but the work
-still needs engineering execution detail.
+Required semantic fields:
 
-Required fields:
-- `父 Issue / 承接关系`
-- `本次工程目标`
-- `范围边界`
-- `验收标准`
+- parent relationship
+- engineering goal
+- scope boundary
+- acceptance criteria
 
-Recommended fields:
-- `涉及模块 / 契约`
-- `技术约束`
-- `实施要点`
-- `风险 / 依赖`
+Optional sections, rendered only when needed:
 
-Optional fields:
-- `迁移步骤`
-- `回滚方案`
-- `关联设计文档 / PR`
+- affected internal contract
+- technical constraints
+- migration or rollback steps
+- risks or dependencies
 
-Standard template:
+Canonical body:
 
 ```text
-## 🔗 父 Issue / 承接关系
-- 父 Issue：...
-- 本子任务承接的目标：...
+## Parent
+- Parent issue: <clickable issue reference>
+- Contribution: <which parent outcome this task advances>
 
-## 🎯 本次工程目标
-- 这次工程交付要完成什么：...
-- 完成后对父 Issue 有什么支撑：...
+## Goal
+<one engineering result this child issue must deliver>
 
-## 🎯 范围边界
-- 本次要做：...
-- 本次不做：...
+## Scope
+- Include: <owned execution boundary>
+- Exclude: <boundary delegated elsewhere>
 
-## 🧩 涉及模块 / 契约
-- 涉及的服务 / 模块 / 仓库：...
-- 涉及的内部契约 / 数据结构 / 接口：...
+## Acceptance
+- [ ] <observable or verifiable engineering result>
+- [ ] <second independent result, when needed>
 
-## ⚙️ 技术约束
-- 依赖限制：...
-- 迁移或兼容性要求：...
-- 回滚或降级要求：...
+[## Constraints]
+<only approved internal contracts, dependencies, compatibility, or rollback>
 
-## 🛠 实施要点
-- 主链路或实施步骤：...
-- 需要重点关注的内部约束：...
-
-## ✅ 验收标准
-- [ ] ...
-- [ ] ...
-
-## ⚠️ 风险 / 依赖
-- 风险点：...
-- 依赖项：...
-- 需要协调的事项：...
-
-## 📎 其他信息
-- 迁移步骤：...
-- 回滚方案：...
-- 关联设计文档 / PR：...
+[## Verification]
+<checks specific to this engineering task>
 ```
 
-Child issue default rules:
+Do not turn a child issue into a repository-wide implementation plan. Split it
+again when it contains independent delivery and rollback units.
 
-- Default this template to `delivery_task` or `implementation_task`.
-- Default audience is `engineering_only`.
-- Internal module, contract, and execution detail are allowed when they are
-  necessary to make the engineering task actionable.
-- Keep the child issue scoped to one execution layer; if it turns into a broad
-  program of work, split again instead of piling unrelated implementation
-  details into one engineering issue.
+## Task or Maintenance Template
 
-## Task / Maintenance Template
+Required semantic fields:
 
-Required fields:
-- `背景 / 目的`
-- `本次范围`
-- `完成标准`
+- concrete problem or maintenance pressure
+- scope
+- done criteria
+- verification
 
-Recommended fields:
-- `影响模块`
-- `风险 / 注意事项`
-- `验证方式`
+Optional sections, rendered only when material:
 
-Optional fields:
-- `兼容性说明`
-- `回滚说明`
-- `关联 Issue / 需求编号`
+- risk or dependency
+- compatibility or rollback consequence
+- related issue
 
-Standard template:
+Canonical body:
 
 ```text
-## 📦 影响模块
-- 涉及的服务 / 模块 / 仓库：...
-- 涉及的文件 / 流程 / 工具：...
+## Problem
+<current concrete problem or maintenance pressure>
 
-## 🎯 背景 / 目的
-- 为什么现在要做：...
-- 当前阻塞 / 低效 / 技术债：...
+## Scope
+- <primary change>
+- <meaningful exclusion, only when needed>
 
-## 🛠 本次范围
-- 本次要做：...
-- 本次不做：...
+## Done
+- [ ] <observable completion condition>
+- [ ] <second independent condition, when needed>
 
-## ✅ 完成标准
-- [ ] ...
-- [ ] ...
+## Verification
+- <check that proves completion>
 
-## 🧪 验证方式
-- 手工验证：...
-- 自动化测试：...
-
-## 📎 其他信息
-- 风险 / 注意事项：...
-- 回滚说明：...
+[## Risks]
+<only real risk, dependency, compatibility, or rollback information>
 ```
 
-## Investigation / Spike Template
+Do not add an `Impact Module` or `Other Information` section by default. Paths,
+tools, links, logs, metrics, compatibility, and rollback belong only when they
+change execution or review decisions.
 
-Required fields:
-- `研究问题`
-- `背景 / 动机`
-- `预期产出`
-- `退出条件 / 范围边界`
+## Investigation or Spike Template
 
-Recommended fields:
-- `备选方案 / 假设`
-- `验证方式`
+Required semantic fields:
 
-Optional fields:
-- `相关链接`
-- `风险说明`
-- `下阶段建议`
+- research question
+- context and uncertainty
+- expected output
+- exit condition and scope boundary
 
-Template:
+Optional sections, rendered only when useful:
+
+- hypotheses or alternatives
+- verification method
+- next decision
+
+Canonical body:
 
 ```text
-## ❓ 研究问题
-- 本次要回答什么问题：...
-- 当前最大不确定性：...
+## Question
+<decision or uncertainty this investigation must resolve>
 
-## 🧩 背景 / 动机
-- 为什么现在要做这次研究 / 预研：...
-- 当前已知限制或前提：...
+## Context
+<why the answer is needed and what is currently unknown>
 
-## 🧪 预期产出
-- 需要形成的结论：...
-- 需要交付的产物：...
+## Deliverables
+- <decision, comparison, prototype, or evidence to produce>
 
-## 🎯 退出条件 / 范围边界
-- 本次要确认：...
-- 本次不做：...
-- 什么情况下可以结束本次研究：...
+## Exit Criteria
+- <what must be known or demonstrated to stop>
+- Out of scope: <boundary that prevents open-ended research>
 
-## 📎 其他信息
-- 备选方案 / 假设：...
-- 验证方式：...
-- 相关链接：...
-- 风险说明：...
-- 下阶段建议：...
+[## Hypotheses]
+<only credible alternatives or assumptions to test>
+
+[## Verification]
+<how evidence will be collected or compared>
 ```
 
-## Template Validation Rule
+## Examples
 
-- Resolve `template_family` and `issue_level` first.
-- Resolve and validate the issue title prefix from `change_type` before create.
-- Validate semantic required fields against the selected template family, not
-  against a single fixed heading set.
-- Validate issue quality as well as field presence: clear problem statement,
-  explicit target outcome, bounded scope, testable acceptance, and
-  audience-appropriate detail.
-- If template-required fields are missing:
-  - `gate_mode=required` => `BLOCK`
-  - `gate_mode=recommended` => `PASS_WITH_WARNING`
-- Validation output must include the resolved `template_family` and
-  `issue_level`.
-- Validation output must distinguish:
-  - `title_prefix`
-  - `title_prefix_warnings`
-  - `missing_required_fields`
-  - `missing_recommended_fields`
-  - `overspecification_warnings`
-- For `feat|integration|workflow|api` work that is clearly backend-, AI-,
-  workflow-, or integration-heavy, missing `技术约束` or `验证方式` should emit
-  an explicit warning.
-- For `spike|research|proposal|investigation` work, missing a concrete
-  `预期产出` or `退出条件 / 范围边界` must be treated as a required-field
-  failure, not a soft omission.
-- If a `parent_requirement` draft contains speculative classes, files, routes,
-  tables, workers, or unapproved architecture splits, emit an
-  `overspecification_warning` and rewrite before presentation.
-- If `child_issue_needed=yes`, validate that:
-  - the parent issue stays product-facing
-  - the child issue carries the necessary engineering detail
-  - the parent/child relationship is explicit
-- Validation output must list missing fields explicitly.
+### Compact Maintenance Issue
 
-## Template-to-Command Mapping Examples
+```text
+docs: require code-local skeletons before non-trivial builds
 
-Use the resolved `template_family` to select template and command payload
-automatically. These examples are the standard drafting shape unless a
-repository-specific template overrides them.
+## Problem
+`workflow-build` accepts prose-only skeletons, so an agent can start a
+non-trivial implementation before exposing its control flow and invariants in
+the code context.
 
-### `feat|integration|workflow|api` => Feature / Change Template => create
+## Scope
+- Require a code-local skeleton before non-trivial implementation.
+- Keep simple edits exempt and preserve the direct-implementation rule.
 
-```bash
-gh issue create \
-  --title "feat: <short feature title>" \
-  --body "$(cat <<'EOF'
-## 📦 影响模块
-- 涉及的服务 / 模块 / 仓库：<module>
-- 涉及的接口 / 数据结构：<contract or n/a>
-- 是否影响现有兼容性：<yes/no + note>
+## Done
+- [ ] The workflow distinguishes code-local skeletons from prose-only exceptions.
+- [ ] The default prompt and skill version describe the same requirement.
 
-## 🧩 背景 / 场景
-- 为什么要做这个需求：<reason>
-- 当前遇到什么问题：<problem>
-- 现有替代方案：<alternative or n/a>
-- 不做的影响：<impact>
-
-## ✨ 需求描述
-1. 当 <trigger> 时，系统应 <behavior>
-2. 系统应 <expected behavior>
-3. 若出现异常或依赖不可用，系统应 <fallback>
-
-## 🎯 范围边界
-- 本次要做：<in scope>
-- 本次不做：<out of scope>
-
-## ⚙️ 技术约束
-- 依赖限制：<constraints or n/a>
-- 性能 / 时延要求：<requirements or n/a>
-- 数据来源 / 外部服务约束：<dependencies or n/a>
-- 回滚或降级要求：<rollback plan or n/a>
-
-## ✅ 验收标准
-- [ ] 功能场景一：<scenario 1>
-- [ ] 功能场景二：<scenario 2>
-- [ ] 兼容性要求：<compatibility>
-- [ ] 回归范围：<regression scope>
-- [ ] 异常 / 降级行为：<failure handling>
-
-## 🧪 验证方式
-- 手工验证：<manual check>
-- 自动化测试：<tests or n/a>
-- 日志 / 指标 / 观测点：<signals or n/a>
-
-## 📎 其他信息
-- 接口文档：<link or n/a>
-- 设计稿：<link or n/a>
-- 关联 Issue / 需求编号：<id or n/a>
-- 风险说明：<risk or n/a>
-EOF
-)"
+## Verification
+- Check the skill, metadata, and negative fixture for the same skeleton rule.
 ```
 
-```bash
-glab issue create \
-  --title "feat: <short feature title>" \
-  --description "$(cat <<'EOF'
-## 📦 影响模块
-- 涉及的服务 / 模块 / 仓库：<module>
-- 涉及的接口 / 数据结构：<contract or n/a>
-- 是否影响现有兼容性：<yes/no + note>
+This issue does not need module inventories, compatibility rows, metrics,
+rollback text, or an `Other Information` section.
 
-## 🧩 背景 / 场景
-- 为什么要做这个需求：<reason>
-- 当前遇到什么问题：<problem>
-- 现有替代方案：<alternative or n/a>
-- 不做的影响：<impact>
+### Detailed Bug Issue
 
-## ✨ 需求描述
-1. 当 <trigger> 时，系统应 <behavior>
-2. 系统应 <expected behavior>
-3. 若出现异常或依赖不可用，系统应 <fallback>
+```text
+bugfix: require independent review before tutorial checkpoint commits
 
-## 🎯 范围边界
-- 本次要做：<in scope>
-- 本次不做：<out of scope>
+## Problem
+The tutorial build workflow lets the author treat its own self-check as an
+acceptance verdict and continue to the next checkpoint.
 
-## ⚙️ 技术约束
-- 依赖限制：<constraints or n/a>
-- 性能 / 时延要求：<requirements or n/a>
-- 数据来源 / 外部服务约束：<dependencies or n/a>
-- 回滚或降级要求：<rollback plan or n/a>
+## Reproduction
+1. Build one tutorial step.
+2. Run the build skill's self-check.
+3. Continue to the next step without an independent review verdict.
 
-## ✅ 验收标准
-- [ ] 功能场景一：<scenario 1>
-- [ ] 功能场景二：<scenario 2>
-- [ ] 兼容性要求：<compatibility>
-- [ ] 回归范围：<regression scope>
-- [ ] 异常 / 降级行为：<failure handling>
+## Expected
+A checkpoint commit requires an independent review pass.
 
-## 🧪 验证方式
-- 手工验证：<manual check>
-- 自动化测试：<tests or n/a>
-- 日志 / 指标 / 观测点：<signals or n/a>
+## Actual
+The build agent can continue after its own self-check.
 
-## 📎 其他信息
-- 接口文档：<link or n/a>
-- 设计稿：<link or n/a>
-- 关联 Issue / 需求编号：<id or n/a>
-- 风险说明：<risk or n/a>
-EOF
-)"
+## Acceptance
+- [ ] Build stops after one step and requests review.
+- [ ] Checkpoint commit requires review-pass evidence.
+- [ ] The next step starts only after the review gate passes.
 ```
 
-### `fix|bugfix|hotfix|incident` => Bug / Incident Template => create
+This bug is longer because reproduction and expected/actual behavior are
+decision-critical, not because every optional template field was rendered.
+
+## Anti-Patterns
+
+| Pattern | Avoid | Prefer |
+|---|---|---|
+| Repeated background | Three bullets restating the same limitation and risk | One concrete current problem |
+| Module inventory | Paths and repositories already obvious from scope | Omit, or keep one affected contract when it changes ownership |
+| Empty optional data | `日志：n/a`, `设计稿：n/a`, `指标：n/a` | Omit the entire section |
+| Scope as implementation plan | File-by-file edits and speculative helper names | Delivery boundary and meaningful exclusion |
+| Acceptance as diff list | "Update file X" and "rename function Y" | Observable behavior or reviewable result |
+| Verification duplication | Restate every acceptance checkbox | Name the check or command that proves them |
+| Parent over-specification | Internal modules, schemas, and sequencing in a product issue | Keep the parent outcome-facing and create a child issue |
+
+## Template Validation
+
+Before accepting a draft:
+
+- [ ] One template family and one canonical body schema are used.
+- [ ] The title prefix matches `change_type`.
+- [ ] The short title names a concrete problem or outcome, or a concrete action
+      and object.
+- [ ] Every required semantic field is supported by user, issue, plan, diff, or
+      repository evidence.
+- [ ] Every supporting fact appears in one owning section.
+- [ ] Acceptance criteria describe observable completion.
+- [ ] Verification describes proof rather than repeating acceptance.
+- [ ] Empty optional sections, `n/a` rows, and placeholder bullets are absent.
+- [ ] Parent issues contain no unnecessary internal implementation detail.
+- [ ] Unknown required facts remain TODOs in dry-run and block confirmed
+      creation until resolved.
+
+## Template-to-Command Mapping
+
+Render the selected canonical template once into `<issue-body-file>`. GitHub
+and GitLab commands consume that same body; command examples must not redefine
+the issue schema.
+
+GitHub:
 
 ```bash
-gh issue create \
-  --title "<resolved-prefix>: <short bug title>" \
-  --body "$(cat <<'EOF'
-## 🐛 问题概述
-<problem summary>
-
-## 🔁 复现步骤
-1. <step 1>
-2. <step 2>
-3. <step 3>
-
-## ✅ 预期结果
-<expected>
-
-## ❌ 实际结果
-<actual>
-
-## 🎯 影响范围 / 严重程度
-- 影响范围：<scope>
-- 严重程度：<severity>
-- 是否可绕过：<yes/no + workaround>
-
-## 🧪 修复验收
-- 修复完成的判断标准：<done criteria>
-- 需要回归的场景：<regression scope>
-
-## 📎 其他信息
-- 日志：<log or n/a>
-- 截图：<link or n/a>
-- 环境信息：<env>
-- 输入样例 / 文件类型 / 任务 ID：<sample or n/a>
-EOF
-)"
+gh issue create -R <owner>/<repo> \
+  --title "<resolved-prefix>: <concrete title>" \
+  --body-file <issue-body-file>
 ```
 
+GitLab:
+
 ```bash
-glab issue create \
-  --title "<resolved-prefix>: <short bug title>" \
-  --description "$(cat <<'EOF'
-## 🐛 问题概述
-<problem summary>
-
-## 🔁 复现步骤
-1. <step 1>
-2. <step 2>
-3. <step 3>
-
-## ✅ 预期结果
-<expected>
-
-## ❌ 实际结果
-<actual>
-
-## 🎯 影响范围 / 严重程度
-- 影响范围：<scope>
-- 严重程度：<severity>
-- 是否可绕过：<yes/no + workaround>
-
-## 🧪 修复验收
-- 修复完成的判断标准：<done criteria>
-- 需要回归的场景：<regression scope>
-
-## 📎 其他信息
-- 日志：<log or n/a>
-- 截图：<link or n/a>
-- 环境信息：<env>
-- 输入样例 / 文件类型 / 任务 ID：<sample or n/a>
-EOF
-)"
+glab issue create -R <group>/<repo> \
+  --title "<resolved-prefix>: <concrete title>" \
+  --description "$(cat <issue-body-file>)"
 ```
 
-### `chore|docs|refactor|test|tooling|config` => Task / Maintenance Template => create
+Existing issue commit bridge:
 
 ```bash
-gh issue create \
-  --title "<resolved-prefix>: <short task title>" \
-  --body "$(cat <<'EOF'
-## 📦 影响模块
-- 涉及的服务 / 模块 / 仓库：<module>
-- 涉及的文件 / 流程 / 工具：<scope>
-- 是否影响现有兼容性：<yes/no + note>
-
-## 🎯 背景 / 目的
-- 为什么现在要做：<reason>
-- 当前阻塞 / 低效 / 技术债：<problem>
-
-## 🛠 本次范围
-- 本次要做：<in scope>
-- 本次不做：<out of scope>
-
-## ✅ 完成标准
-- [ ] <done criteria 1>
-- [ ] <done criteria 2>
-
-## 🧪 验证方式
-- 手工验证：<manual check or n/a>
-- 自动化测试：<tests or n/a>
-- 日志 / 指标 / 观测点：<signals or n/a>
-
-## 📎 其他信息
-- 风险 / 注意事项：<risk or n/a>
-- 兼容性说明：<compat note or n/a>
-- 回滚说明：<rollback or n/a>
-- 关联 Issue / 需求编号：<id or n/a>
-EOF
-)"
-```
-
-```bash
-glab issue create \
-  --title "<resolved-prefix>: <short task title>" \
-  --description "$(cat <<'EOF'
-## 📦 影响模块
-- 涉及的服务 / 模块 / 仓库：<module>
-- 涉及的文件 / 流程 / 工具：<scope>
-- 是否影响现有兼容性：<yes/no + note>
-
-## 🎯 背景 / 目的
-- 为什么现在要做：<reason>
-- 当前阻塞 / 低效 / 技术债：<problem>
-
-## 🛠 本次范围
-- 本次要做：<in scope>
-- 本次不做：<out of scope>
-
-## ✅ 完成标准
-- [ ] <done criteria 1>
-- [ ] <done criteria 2>
-
-## 🧪 验证方式
-- 手工验证：<manual check or n/a>
-- 自动化测试：<tests or n/a>
-- 日志 / 指标 / 观测点：<signals or n/a>
-
-## 📎 其他信息
-- 风险 / 注意事项：<risk or n/a>
-- 兼容性说明：<compat note or n/a>
-- 回滚说明：<rollback or n/a>
-- 关联 Issue / 需求编号：<id or n/a>
-EOF
-)"
-```
-
-### `spike|research|proposal|investigation` => Investigation / Spike Template => create
-
-```bash
-gh issue create \
-  --title "proposal: <short investigation title>" \
-  --body "$(cat <<'EOF'
-## ❓ 研究问题
-- 本次要回答什么问题：<question>
-- 当前最大不确定性：<unknown>
-
-## 🧩 背景 / 动机
-- 为什么现在要做这次研究 / 预研：<reason>
-- 当前已知限制或前提：<constraints>
-
-## 🧪 预期产出
-- 需要形成的结论：<expected conclusion>
-- 需要交付的产物：<artifact>
-
-## 🎯 退出条件 / 范围边界
-- 本次要确认：<in scope>
-- 本次不做：<out of scope>
-- 什么情况下可以结束本次研究：<exit condition>
-
-## 📎 其他信息
-- 备选方案 / 假设：<alternatives or hypotheses>
-- 验证方式：<validation>
-- 相关链接：<links or n/a>
-- 风险说明：<risk or n/a>
-- 下阶段建议：<next step or n/a>
-EOF
-)"
-```
-
-```bash
-glab issue create \
-  --title "proposal: <short investigation title>" \
-  --description "$(cat <<'EOF'
-## ❓ 研究问题
-- 本次要回答什么问题：<question>
-- 当前最大不确定性：<unknown>
-
-## 🧩 背景 / 动机
-- 为什么现在要做这次研究 / 预研：<reason>
-- 当前已知限制或前提：<constraints>
-
-## 🧪 预期产出
-- 需要形成的结论：<expected conclusion>
-- 需要交付的产物：<artifact>
-
-## 🎯 退出条件 / 范围边界
-- 本次要确认：<in scope>
-- 本次不做：<out of scope>
-- 什么情况下可以结束本次研究：<exit condition>
-
-## 📎 其他信息
-- 备选方案 / 假设：<alternatives or hypotheses>
-- 验证方式：<validation>
-- 相关链接：<links or n/a>
-- 风险说明：<risk or n/a>
-- 下阶段建议：<next step or n/a>
-EOF
-)"
-```
-
-### Existing Issue => link for commit
-
-```bash
-# gh
+# GitHub
 gh issue comment <issue_number> --body "Linking commit: <sha>"
 ```
 
 ```bash
-# glab
+# GitLab
 glab issue note <issue_number> -m "Linking commit: <sha>"
 ```

--- a/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/references/required-gitlab-flow-example.md
+++ b/agent-specs/engineering/skills/delivery-workflow/issue-gate-skill/references/required-gitlab-flow-example.md
@@ -29,13 +29,14 @@ export GITLAB_HOST=<gitlab-host>
 glab issue list -R <group>/<repo> --search "Cypher retriever" --per-page 20
 glab issue create -R <group>/<repo> \
   --title "feat: 完成 Cypher retriever 首版实现" \
-  --description "<auto-drafted feature template body>"
+  --description "$(cat <issue-body-file>)"
 ```
 
 Expected dry-run outcome:
 
 - no matching open issue is found
-- a feature-template issue draft is ready for confirmation
+- one canonical feature-template body is rendered to `<issue-body-file>` and
+  ready for confirmation
 - the future commit bridge will be ISSUE: #<issue_number>
 
 ## 3. Human Confirmation
@@ -72,9 +73,11 @@ Successful gate output should include:
 - result: PASS
 - reason: existing open issue not found; new issue created successfully
 
-## Platform
-- selected: glab
+## Target
+- selected_platform: glab
 - cli_ready: yes
+- target_repo: <group>/<repo>
+- search_scope: upstream_repo
 
 ## Issue Action
 - action: create


### PR DESCRIPTION
## Why

- Routine issue drafts repeated the same facts across full templates and kept empty fields that slowed down review.
- Commit examples still favored internal identifiers and command reports over the behavior a reader needs to understand.

## What

- Make issue drafting select the shortest complete set of facts and share one body contract across GitHub and GitLab.
- Keep the commit message's five sections while making each section describe observable behavior, boundaries, and test coverage.
- Add positive and negative examples that distinguish readable explanations from abstract wording, diff inventories, and command-only test notes.

## Impact

- Issue readers can identify the problem, scope, acceptance conditions, and verification without template filler or repeated context.
- Commit readers can understand what prompted a change, what behavior now differs, and what remains unchanged without reconstructing intent from internal names.

## Tests

- Issue fixtures verify routine maintenance drafts stay concise, omit empty optional sections, and use the same body in GitHub and GitLab creation flows.
- Commit fixtures verify all five sections remain present and that test notes state the covered condition and expected result.
- Metadata and YAML checks verify both skills remain discoverable and parseable.

## Refs

- #23
- #24
