### PR TITLE
docs(git-commit): make Impact, Verification, and Refs conditional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,9 @@
 - Ask for missing requirements before writing.
 - Provide outcome-focused updates: deliverables, risks, next steps, support needed.
 - Do not auto-stage unrelated changes.
-- Keep `Why/What/Impact/Tests` in every structured commit body. Add `Refs`
-  only when a real, verified reference exists.
+- Keep `Why/What` in every structured commit body. Add `Impact` only for an
+  independent effect or preserved boundary, `Verification` only for actual
+  result-bearing evidence, and `Refs` only for a real, verified reference.
 
 ## Quality Bar
 - Every change must be explainable in one sentence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,8 @@
 - Ask for missing requirements before writing.
 - Provide outcome-focused updates: deliverables, risks, next steps, support needed.
 - Do not auto-stage unrelated changes.
-- Keep commits in full template format (Why/What/Impact/Tests/Refs).
+- Keep `Why/What/Impact/Tests` in every structured commit body. Add `Refs`
+  only when a real, verified reference exists.
 
 ## Quality Bar
 - Every change must be explainable in one sentence.

--- a/agent-specs/engineering/skills/delivery-workflow/README.md
+++ b/agent-specs/engineering/skills/delivery-workflow/README.md
@@ -12,7 +12,7 @@ whole package as a ritual sequence.
 | Situation | Use |
 | --- | --- |
 | Planned work needs canonical issue traceability, issue drafts, task-to-issue mapping, or a commit `Refs` bridge. | [`issue-gate-skill`](issue-gate-skill/SKILL.md) |
-| Verified local changes need staging, split decisions, and structured `Why / What / Impact / Tests / Refs` commits. | [`git-commit-skill`](git-commit-skill/SKILL.md) |
+| Verified local changes need staging, split decisions, and structured `Why / What / Impact / Tests` commits with references when available. | [`git-commit-skill`](git-commit-skill/SKILL.md) |
 | One tutorial or learning document checkpoint needs a Git save point with freeze metadata while the document body stays reader-friendly. | [`single-doc-checkpoint-commit-skill`](single-doc-checkpoint-commit-skill/SKILL.md) |
 | One mixed branch needs independent review slices, branches, and one PR/MR per accepted slice. | [`split-pr-publish-skill`](split-pr-publish-skill/SKILL.md) |
 | A GitHub PR or GitLab MR needs evidence-backed findings, a verdict, and optional review publication. | [`pr-mr-review-publish-skill`](pr-mr-review-publish-skill/SKILL.md) |

--- a/agent-specs/engineering/skills/delivery-workflow/README.md
+++ b/agent-specs/engineering/skills/delivery-workflow/README.md
@@ -12,7 +12,7 @@ whole package as a ritual sequence.
 | Situation | Use |
 | --- | --- |
 | Planned work needs canonical issue traceability, issue drafts, task-to-issue mapping, or a commit `Refs` bridge. | [`issue-gate-skill`](issue-gate-skill/SKILL.md) |
-| Verified local changes need staging, split decisions, and structured `Why / What / Impact / Tests` commits with references when available. | [`git-commit-skill`](git-commit-skill/SKILL.md) |
+| Verified local changes need staging, split decisions, and structured `Why / What` commits with conditional impact, verification, and references. | [`git-commit-skill`](git-commit-skill/SKILL.md) |
 | One tutorial or learning document checkpoint needs a Git save point with freeze metadata while the document body stays reader-friendly. | [`single-doc-checkpoint-commit-skill`](single-doc-checkpoint-commit-skill/SKILL.md) |
 | One mixed branch needs independent review slices, branches, and one PR/MR per accepted slice. | [`split-pr-publish-skill`](split-pr-publish-skill/SKILL.md) |
 | A GitHub PR or GitLab MR needs evidence-backed findings, a verdict, and optional review publication. | [`pr-mr-review-publish-skill`](pr-mr-review-publish-skill/SKILL.md) |

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-skill
-description: v0.2.7 - Draft, split, and execute atomic scoped Git commits with behavior-first Why/What/Impact/Tests bodies, distinct effect and verification evidence, and Refs only for verified references. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
+description: v0.2.8 - Draft, split, and execute atomic scoped Git commits with required behavior-first Why/What and conditional Impact/Verification/Refs evidence. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
 ---
 
 # Git Commit Skill
@@ -10,8 +10,8 @@ description: v0.2.7 - Draft, split, and execute atomic scoped Git commits with b
 Prepare commit-stage work as a verified, traceable save point. This skill
 decides whether the current diff should be committed, split, or only drafted;
 then it stages only approved in-scope files and writes a repository-quality
-commit message with concrete `Why / What / Impact / Tests` evidence and a
-`Refs` section only when a real, verified reference exists.
+commit message with a concrete `Why / What` core. It adds `Impact`,
+`Verification`, and `Refs` only when each section has independent evidence.
 The sections must tell one causal story without replacing observable changes
 with intent summaries such as "clarify responsibility" or "improve
 consistency." Each supporting detail appears once, in the section that owns
@@ -58,11 +58,10 @@ issue mapping, and use review or CI skills for review/CI failures.
 
 - commit standard: Conventional Commits unless the repository explicitly uses
   another convention
-- commit body format: exact `Why / What / Impact / Tests`, followed by `Refs`
-  only when a real, verified reference exists
-- section rule: each required body section appears exactly once; optional
-  `Refs` appears at most once; multiple independent tested boundaries are
-  bullets under the single `Tests` section
+- commit body format: exact `Why / What`, followed in order by `Impact`,
+  `Verification`, and `Refs` only when each conditional section has evidence
+- section rule: `Why` and `What` appear exactly once; each conditional section
+  appears at most once, with multiple verification results listed as bullets
 - evidence rule: derive the subject and every section from the user request,
   issue, staged diff, or verification results
 - density rule: use one bullet with one sentence per section by default; add a
@@ -73,9 +72,9 @@ issue mapping, and use review or CI skills for review/CI failures.
 - impact rule: state the post-merge observable effect, compatibility result,
   or explicitly preserved boundary; do not describe how the change was
   verified
-- tests rule: state the condition, scenario, or boundary actually verified
-  and its expected result when material; do not repeat `Impact`, claim
-  unverified behavior, or replace evidence with a command
+- verification rule: pair every recorded check, condition, or scenario with an
+  observed result; allow concise suite counts, but keep raw commands and
+  `PASS:` markers in the execution report
 - execution mode: full commit execution for normal commit-stage work
 - split policy: atomic save-point commits, based on
   `commit-execution-policy.md`
@@ -86,19 +85,23 @@ issue mapping, and use review or CI skills for review/CI failures.
 - staging policy: stage only approved, in-scope files
 - unrelated changes: ignore by default
 - mixed authorship files: ask once before staging
+- optional impact fallback: omit `Impact` when it adds no consequence,
+  compatibility fact, or preserved boundary beyond `What`
+- optional verification fallback: omit `Verification` when no useful result
+  evidence exists and report the operational reason after execution
 - optional traceability fallback: omit the entire `Refs` section
 
-## Impact And Tests Boundary
+## Conditional Impact And Verification
 
 | Section | Write | Do not write |
 |---|---|---|
 | `Impact` | Post-merge observable effects, compatibility, and explicitly preserved boundaries | Test commands, test files, or verification steps |
-| `Tests` | Conditions, scenarios, and expected results actually verified | Generic "tested" claims, change benefits, repeated `Impact`, or command-only lists |
+| `Verification` | Actual suite outcomes or checked conditions paired with observed results | Bare coverage inventories, raw commands, `PASS:` prefixes, or repeated `Impact` |
 
-Read the two sections independently before accepting them. `Impact` must still
-explain who or what is affected when `Tests` is hidden. `Tests` must still show
-what condition was exercised and what result was expected when `Impact` is
-hidden. If one sentence could fill both sections unchanged, rewrite it.
+Render either section only when it remains useful by itself. `Impact` must add
+a consequence beyond `What`; `Verification` must add evidence beyond the
+change claim. If a section only repeats another section or fills the template,
+omit it.
 
 ## The Operating Loop
 
@@ -113,8 +116,8 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
      mixed-authorship files.
    - When repository language is unclear, sample recent non-merge commits for
      concrete verbs, background phrasing, behavior vocabulary, and testing
-     language. Do not replace this skill's required four-section core or its
-     conditional `Refs` rule.
+     language. Do not replace this skill's required `Why / What` core or its
+     conditional section rules.
    - Treat the save-point order as:
      `worktree -> issue -> verified slice -> issue-gate -> commit`.
 3. Run traceability gate when required.
@@ -133,11 +136,10 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
    - Read `references/commit-message-standard.md`.
    - Record the concrete primary action and object from the staged diff.
    - Record the previous behavior or pressure, the resulting behavior or
-     structure, the material impact boundary, the behavior exercised by tests,
-     the checks that actually ran, and verified references.
-   - Keep tested behavior separate from execution evidence: `Tests` explains
-     coverage, while commands and pass or fail results belong in the execution
-     report.
+     structure, any independent impact, useful verification results, the checks
+     that actually ran, and verified references.
+   - Keep concise result evidence in `Verification`; keep raw commands,
+     `PASS:` markers, and skipped-check reasons in the execution report.
    - Select the smallest useful fact for each message section; do not render
      every fact collected in the evidence card.
 6. Write and challenge the subject and body.
@@ -150,18 +152,18 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
    - Omit internal fields, files, helper names, and call-site counts that the
      diff already shows. Keep an identifier only when it materially improves
      recognition under the language rule.
-   - Render the exact core section order: `Why`, `What`, `Impact`, `Tests`.
-     Append `Refs` only when verified traceability exists.
+   - Render `Why` and `What` exactly once. Append `Impact`, `Verification`, and
+     `Refs` in that order only when each section has independent evidence.
    - Give each rendered section one job: reason, change, effect, proof, or
      reference.
      Do not repeat tests, call-site counts, assertions, or state tables across
      sections.
-   - In `Tests`, name the behavior or boundary covered. Add the expected result
-     or prevented failure when that is the important regression signal. Do not
-     write a command, `PASS`, or "added a test" there.
-   - Make the sections read as one chain: previous problem -> implemented
-     change -> observable result or preserved boundary -> proof, followed by a
-     reference only when one exists.
+   - In `Verification`, pair every retained check or condition with an observed
+     result. A named suite and total may be concise evidence; a list of
+     components or "covered boundaries" is not.
+   - Make the rendered sections read as one chain: previous problem ->
+     implemented change [-> independent consequence] [-> evidence]
+     [-> reference].
 7. Execute the selected path.
    - For `draft_only` or `split_only`, return the draft or split plan without
      staging.
@@ -170,7 +172,7 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
      `git commit -F <file>`.
 8. Report the save point.
    - Include commit hash when committed.
-   - Include staged scope, traceability status, tests status, and any remaining
+   - Include staged scope, traceability status, checks status, and any remaining
      unstaged scope.
 
 ## Decision Points
@@ -189,9 +191,10 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
 - If a precise identifier makes the subject long or hard to read, use the
   established project noun in the subject and leave the identifier to `What`
   or the diff.
-- If a test fact appears in `Why`, `What`, or `Impact`, move the covered
-  behavior to `Tests` unless the test itself is the primary change. Keep the
-  command and result in the execution report.
+- If `Impact` only restates the result already clear from `What`, omit it.
+- If verification evidence is only a raw command, `PASS:` marker, file name,
+  component list, or uncovered claim, omit `Verification` and keep the
+  execution detail in the report.
 - If call-site counts or individual assertions do not change the reader's
   understanding, omit them.
 - If the reason or impact cannot be supported, state the narrow verified
@@ -210,22 +213,20 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
 | "All the files are already dirty, so staging everything is fastest." | Dirty is not the same as in scope. Stage only approved files for the current save point. |
 | "The issue is obvious, so I can write a plausible Refs line." | Traceability must come from `issue-gate-skill`, repository evidence, or explicit user input. If it is optional and absent, omit `Refs`. |
 | "A fixed template is easier to validate, so an empty Refs needs n/a." | A placeholder records template administration, not project knowledge. Keep the traceability check, but omit the section when no reference exists. |
-| "This is just docs, so a one-line commit is fine." | Repository history still needs Why, What, Impact, and Tests; add Refs only for a real reference. |
+| "This is just docs, so a one-line commit is fine." | Repository history still needs Why and What; add conditional sections only for independent evidence. |
 | "Clarify responsibility summarizes a rename." | Intent is not an observable change. Name the renamed object, and use the real identifier when it improves recognition. |
 | "The body can report that the change improves consistency." | Broad quality claims hide behavior. State the previous and resulting behavior or the exact boundary that stayed unchanged. |
 | "More identifiers and state values make the message more concrete." | Detail is useful only in its owning section. Prefer the shortest established project terms that preserve meaning. |
 | "Every discovered fact should appear in the body." | The evidence card is an input filter, not an output checklist. Keep only what a future reader needs. |
 | "The diff is large but it is easier to review as one commit." | Large mixed commits hide intent and rollback boundaries; split unless the change is one inseparable unit. |
-| "Tests are already in the execution report." | The repository requires durable verification evidence in the single Tests section. |
-| "I can add another Tests section for the second command." | Commands stay in the execution report. The body has one Tests section for covered behavior. |
-| "Tests should list the command that passed." | Commands prove execution elsewhere. Commit prose should state the behavior covered and the result when it matters. |
-| "Tests should say that I added regression coverage." | That narrates the test diff. Name the behavior or boundary the coverage protects. |
+| "Verification should list every command that passed." | Commands stay in the execution report. Keep only concise suite outcomes or behavior results that help future readers. |
+| "No Verification section means no checks ran." | Section presence records durable evidence, not execution completeness; the execution report still records checks and omissions. |
 | "Internal names make every section more concrete." | Internal inventory is already visible in the diff. Keep only names that carry contract or state-transition meaning. |
 
 ## Red Flags
 
 - `git add .` or broad staging appears while unrelated dirty files exist.
-- The commit body lacks one of `Why`, `What`, `Impact`, or `Tests`.
+- The commit body lacks `Why` or `What`.
 - The same required section appears more than once.
 - The subject names an intention or quality such as "明确职责", "优化逻辑",
   "提升一致性", or "clarify behavior" without naming the staged action.
@@ -236,20 +237,22 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
 - `Why` restates the subject instead of naming the previous problem or trigger.
 - `Why` explains why a test was added or speculates about a future regression.
 - `What` avoids the actual behavior, structure, identifier, or state value.
-- `What` reports call-site counts or test assertions that belong in the diff or
-  `Tests`.
+- `What` reports call-site counts or assertions that belong in the diff or
+  `Verification`.
 - `Impact` claims a generic benefit instead of an observable result or
   preserved boundary.
 - `Impact` repeats a state-by-state result table for a behavior-preserving
   refactor.
+- `Impact` repeats `What` without adding an affected user, compatibility fact,
+  or preserved boundary.
 - `Refs` is empty, contains `n/a` or `none`, or names a reference that was not
   verified or supplied.
 - Independent feature, refactor, formatting, dependency, or generated-file
   changes are bundled together for speed.
-- Tests are marked as "not requested" instead of giving a real operational
-  reason.
-- `Tests` lists commands, `PASS`, test file names, or "added coverage" without
-  naming the behavior or boundary exercised.
+- `Verification` is empty, contains a skipped-check reason, or exists only to
+  satisfy the template.
+- `Verification` lists raw commands, `PASS:` prefixes, files, components, or
+  covered boundaries without a concise observed result.
 - Internal fields, helpers, paths, or call-site counts appear without explaining
   their behavior-level significance.
 
@@ -262,19 +265,18 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
       intended quality.
 - [ ] The subject uses natural project language and contains no coined noun
       stack.
-- [ ] `Why -> What -> Impact` forms a factual cause-and-result chain.
-- [ ] Commit message has exactly one `Why`, `What`, `Impact`, and `Tests`
-      section in that order; `Refs` appears after `Tests` only when verified
-      traceability exists.
-- [ ] Every claim is grounded in the request, issue, staged diff, or tests.
+- [ ] `Why -> What` forms a factual cause-and-result core; each conditional
+      section adds independent information.
+- [ ] Commit message has exactly one `Why` and `What`; conditional `Impact`,
+      `Verification`, and `Refs` appear at most once in that order.
+- [ ] Every claim is grounded in the request, issue, staged diff, or
+      verification results.
 - [ ] Each supporting detail appears in only one owning section, with one
       bullet per section unless a second independent fact is necessary.
-- [ ] `Tests` states the behavior or boundary exercised and includes the
-      expected result when it is material; commands and results stay in the
-      execution report.
-- [ ] `Impact` remains meaningful without test context, while `Tests` remains
-      meaningful without impact context by naming an exercised condition and
-      expected result.
+- [ ] `Impact` appears only when it adds an independent consequence,
+      compatibility fact, or preserved boundary.
+- [ ] `Verification` appears only when it records an actual suite outcome or
+      checked condition with an observed result.
 - [ ] Internal identifiers appear only when they carry public contract,
       change-object, or state-transition meaning.
 - [ ] Traceability is verified through `issue-gate-skill`, repository evidence,
@@ -282,7 +284,7 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
       `Refs` entirely.
 - [ ] Required pre-commit hygiene checks from
       `references/commit-execution-policy.md` were run or explicitly blocked.
-- [ ] Execution result reports commit hash, test status, and remaining
+- [ ] Execution result reports commit hash, checks status, and remaining
       unstaged scope.
 
 ## Output Format
@@ -307,7 +309,7 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
 ## Execution Result
 - committed: yes | no
 - commit_hash:
-- tests_status:
+- checks_status:
 - notes:
 ```
 
@@ -318,13 +320,11 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
   confirmation.
 - Do not continue to commit execution when `issue-gate-skill` returns `BLOCK`.
 - Do not write single-line commit messages.
-- Do not duplicate body sections; `Why`, `What`, `Impact`, and `Tests` must each
-  appear exactly once, while `Refs` appears at most once when a verified
-  reference exists.
-- Do not render an empty `Refs` section or use `n/a`, `none`, or another
-  placeholder as traceability.
-- Do not create a second `Tests` section for another command; add another
-  bullet under the existing `Tests` section.
+- Do not duplicate body sections; `Why` and `What` must each appear exactly
+  once, while `Impact`, `Verification`, and `Refs` appear at most once when
+  supported.
+- Do not render an empty conditional section or use `n/a`, `none`, or another
+  placeholder.
 - Do not squash independent save points into one broad commit merely for speed.
 - Do not accumulate verified increments into a giant end-of-task commit.
 - Do not split tightly coupled code, tests, and docs when they form one
@@ -334,12 +334,12 @@ hidden. If one sentence could fill both sections unchanged, rewrite it.
   inseparable.
 - Do not treat size limits as hard math; use them as review and rollback risk
   signals.
-- Do not use `"not requested"` as the explanation for missing tests; use a real
-  operational reason.
-- Do not put routine commands, `PASS` markers, or test-file inventory in the
-  commit message; report them after execution.
-- Do not use the same sentence or claim for `Impact` and `Tests`; effect and
-  verification are separate evidence.
+- Do not put raw commands, `PASS:` markers, skipped-check reasons, or test-file
+  inventory in the commit message; report them after execution.
+- Do not accept `Verification` that only enumerates components, scenarios, or
+  boundaries; every retained item needs an observed result.
+- Do not use the same sentence or claim for `Impact` and `Verification`;
+  consequence and evidence are separate facts.
 - Do not require an AI session identifier unless the repository explicitly
   requires it.
 - Do not amend, rebase, or force-push unless the user explicitly asks.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-skill
-description: v0.2.6 - Draft, split, and execute atomic scoped Git commits with behavior-first Why/What/Impact/Tests bodies, adding Refs only for verified references. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
+description: v0.2.7 - Draft, split, and execute atomic scoped Git commits with behavior-first Why/What/Impact/Tests bodies, distinct effect and verification evidence, and Refs only for verified references. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
 ---
 
 # Git Commit Skill
@@ -70,9 +70,12 @@ issue mapping, and use review or CI skills for review/CI failures.
 - language rule: default every section to behavior-level prose; keep an
   internal identifier only when it is a public contract, the direct change
   object, or necessary to distinguish a state transition
-- tests rule: state the behavior or boundary covered and add the expected
-  result when it is material; keep commands and pass or fail results in the
-  execution report
+- impact rule: state the post-merge observable effect, compatibility result,
+  or explicitly preserved boundary; do not describe how the change was
+  verified
+- tests rule: state the condition, scenario, or boundary actually verified
+  and its expected result when material; do not repeat `Impact`, claim
+  unverified behavior, or replace evidence with a command
 - execution mode: full commit execution for normal commit-stage work
 - split policy: atomic save-point commits, based on
   `commit-execution-policy.md`
@@ -84,6 +87,18 @@ issue mapping, and use review or CI skills for review/CI failures.
 - unrelated changes: ignore by default
 - mixed authorship files: ask once before staging
 - optional traceability fallback: omit the entire `Refs` section
+
+## Impact And Tests Boundary
+
+| Section | Write | Do not write |
+|---|---|---|
+| `Impact` | Post-merge observable effects, compatibility, and explicitly preserved boundaries | Test commands, test files, or verification steps |
+| `Tests` | Conditions, scenarios, and expected results actually verified | Generic "tested" claims, change benefits, repeated `Impact`, or command-only lists |
+
+Read the two sections independently before accepting them. `Impact` must still
+explain who or what is affected when `Tests` is hidden. `Tests` must still show
+what condition was exercised and what result was expected when `Impact` is
+hidden. If one sentence could fill both sections unchanged, rewrite it.
 
 ## The Operating Loop
 
@@ -257,6 +272,9 @@ issue mapping, and use review or CI skills for review/CI failures.
 - [ ] `Tests` states the behavior or boundary exercised and includes the
       expected result when it is material; commands and results stay in the
       execution report.
+- [ ] `Impact` remains meaningful without test context, while `Tests` remains
+      meaningful without impact context by naming an exercised condition and
+      expected result.
 - [ ] Internal identifiers appear only when they carry public contract,
       change-object, or state-transition meaning.
 - [ ] Traceability is verified through `issue-gate-skill`, repository evidence,
@@ -320,6 +338,8 @@ issue mapping, and use review or CI skills for review/CI failures.
   operational reason.
 - Do not put routine commands, `PASS` markers, or test-file inventory in the
   commit message; report them after execution.
+- Do not use the same sentence or claim for `Impact` and `Tests`; effect and
+  verification are separate evidence.
 - Do not require an AI session identifier unless the repository explicitly
   requires it.
 - Do not amend, rebase, or force-push unless the user explicitly asks.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-skill
-description: v0.2.5 - Draft, split, and execute atomic scoped Git commits with verified traceability and behavior-first Why/What/Impact/Tests/Refs bodies. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
+description: v0.2.6 - Draft, split, and execute atomic scoped Git commits with behavior-first Why/What/Impact/Tests bodies, adding Refs only for verified references. Use when preparing final commits, reviewing commit wording, staging approved files, or enforcing repository commit conventions.
 ---
 
 # Git Commit Skill
@@ -10,7 +10,8 @@ description: v0.2.5 - Draft, split, and execute atomic scoped Git commits with v
 Prepare commit-stage work as a verified, traceable save point. This skill
 decides whether the current diff should be committed, split, or only drafted;
 then it stages only approved in-scope files and writes a repository-quality
-commit message with concrete `Why / What / Impact / Tests / Refs` evidence.
+commit message with concrete `Why / What / Impact / Tests` evidence and a
+`Refs` section only when a real, verified reference exists.
 The sections must tell one causal story without replacing observable changes
 with intent summaries such as "clarify responsibility" or "improve
 consistency." Each supporting detail appears once, in the section that owns
@@ -57,9 +58,11 @@ issue mapping, and use review or CI skills for review/CI failures.
 
 - commit standard: Conventional Commits unless the repository explicitly uses
   another convention
-- commit body format: exact `Why / What / Impact / Tests / Refs`
-- section rule: each required body section appears exactly once; multiple
-  independent tested boundaries are bullets under the single `Tests` section
+- commit body format: exact `Why / What / Impact / Tests`, followed by `Refs`
+  only when a real, verified reference exists
+- section rule: each required body section appears exactly once; optional
+  `Refs` appears at most once; multiple independent tested boundaries are
+  bullets under the single `Tests` section
 - evidence rule: derive the subject and every section from the user request,
   issue, staged diff, or verification results
 - density rule: use one bullet with one sentence per section by default; add a
@@ -80,7 +83,7 @@ issue mapping, and use review or CI skills for review/CI failures.
 - staging policy: stage only approved, in-scope files
 - unrelated changes: ignore by default
 - mixed authorship files: ask once before staging
-- low-risk traceability fallback: `Refs: - n/a`
+- optional traceability fallback: omit the entire `Refs` section
 
 ## The Operating Loop
 
@@ -95,7 +98,8 @@ issue mapping, and use review or CI skills for review/CI failures.
      mixed-authorship files.
    - When repository language is unclear, sample recent non-merge commits for
      concrete verbs, background phrasing, behavior vocabulary, and testing
-     language. Do not replace this skill's required five-section structure.
+     language. Do not replace this skill's required four-section core or its
+     conditional `Refs` rule.
    - Treat the save-point order as:
      `worktree -> issue -> verified slice -> issue-gate -> commit`.
 3. Run traceability gate when required.
@@ -131,15 +135,18 @@ issue mapping, and use review or CI skills for review/CI failures.
    - Omit internal fields, files, helper names, and call-site counts that the
      diff already shows. Keep an identifier only when it materially improves
      recognition under the language rule.
-   - Render the exact section order: `Why`, `What`, `Impact`, `Tests`, `Refs`.
-   - Give each section one job: reason, change, effect, proof, or reference.
+   - Render the exact core section order: `Why`, `What`, `Impact`, `Tests`.
+     Append `Refs` only when verified traceability exists.
+   - Give each rendered section one job: reason, change, effect, proof, or
+     reference.
      Do not repeat tests, call-site counts, assertions, or state tables across
      sections.
    - In `Tests`, name the behavior or boundary covered. Add the expected result
      or prevented failure when that is the important regression signal. Do not
      write a command, `PASS`, or "added a test" there.
    - Make the sections read as one chain: previous problem -> implemented
-     change -> observable result or preserved boundary -> proof -> reference.
+     change -> observable result or preserved boundary -> proof, followed by a
+     reference only when one exists.
 7. Execute the selected path.
    - For `draft_only` or `split_only`, return the draft or split plan without
      staging.
@@ -159,8 +166,9 @@ issue mapping, and use review or CI skills for review/CI failures.
   file or require a narrower patch.
 - If `issue-gate-skill` returns `BLOCK`, stop commit execution and report the
   blocker.
-- If traceability is optional and no canonical issue applies, use
-  `Refs: - n/a`; do not invent an issue.
+- If traceability is optional and no verified issue, spec, incident, or PR
+  applies, omit the entire `Refs` section; do not invent a reference or render
+  a placeholder.
 - If the primary action or object cannot be named from the staged diff, inspect
   again instead of substituting an intent phrase.
 - If a precise identifier makes the subject long or hard to read, use the
@@ -185,8 +193,9 @@ issue mapping, and use review or CI skills for review/CI failures.
 | Rationalization | Reality |
 |---|---|
 | "All the files are already dirty, so staging everything is fastest." | Dirty is not the same as in scope. Stage only approved files for the current save point. |
-| "The issue is obvious, so I can write a plausible Refs line." | Traceability must come from `issue-gate-skill`, repository evidence, or `n/a`; never invent issue links. |
-| "This is just docs, so a one-line commit is fine." | Repository history still needs Why, What, Impact, Tests, and Refs. |
+| "The issue is obvious, so I can write a plausible Refs line." | Traceability must come from `issue-gate-skill`, repository evidence, or explicit user input. If it is optional and absent, omit `Refs`. |
+| "A fixed template is easier to validate, so an empty Refs needs n/a." | A placeholder records template administration, not project knowledge. Keep the traceability check, but omit the section when no reference exists. |
+| "This is just docs, so a one-line commit is fine." | Repository history still needs Why, What, Impact, and Tests; add Refs only for a real reference. |
 | "Clarify responsibility summarizes a rename." | Intent is not an observable change. Name the renamed object, and use the real identifier when it improves recognition. |
 | "The body can report that the change improves consistency." | Broad quality claims hide behavior. State the previous and resulting behavior or the exact boundary that stayed unchanged. |
 | "More identifiers and state values make the message more concrete." | Detail is useful only in its owning section. Prefer the shortest established project terms that preserve meaning. |
@@ -201,7 +210,7 @@ issue mapping, and use review or CI skills for review/CI failures.
 ## Red Flags
 
 - `git add .` or broad staging appears while unrelated dirty files exist.
-- The commit body lacks one of `Why`, `What`, `Impact`, `Tests`, or `Refs`.
+- The commit body lacks one of `Why`, `What`, `Impact`, or `Tests`.
 - The same required section appears more than once.
 - The subject names an intention or quality such as "明确职责", "优化逻辑",
   "提升一致性", or "clarify behavior" without naming the staged action.
@@ -218,7 +227,8 @@ issue mapping, and use review or CI skills for review/CI failures.
   preserved boundary.
 - `Impact` repeats a state-by-state result table for a behavior-preserving
   refactor.
-- `Refs` names an issue that was not verified or supplied.
+- `Refs` is empty, contains `n/a` or `none`, or names a reference that was not
+  verified or supplied.
 - Independent feature, refactor, formatting, dependency, or generated-file
   changes are bundled together for speed.
 - Tests are marked as "not requested" instead of giving a real operational
@@ -238,8 +248,9 @@ issue mapping, and use review or CI skills for review/CI failures.
 - [ ] The subject uses natural project language and contains no coined noun
       stack.
 - [ ] `Why -> What -> Impact` forms a factual cause-and-result chain.
-- [ ] Commit message has exactly one `Why`, `What`, `Impact`, `Tests`, and
-      `Refs` section in that order.
+- [ ] Commit message has exactly one `Why`, `What`, `Impact`, and `Tests`
+      section in that order; `Refs` appears after `Tests` only when verified
+      traceability exists.
 - [ ] Every claim is grounded in the request, issue, staged diff, or tests.
 - [ ] Each supporting detail appears in only one owning section, with one
       bullet per section unless a second independent fact is necessary.
@@ -249,7 +260,8 @@ issue mapping, and use review or CI skills for review/CI failures.
 - [ ] Internal identifiers appear only when they carry public contract,
       change-object, or state-transition meaning.
 - [ ] Traceability is verified through `issue-gate-skill`, repository evidence,
-      explicit user input, or `Refs: - n/a`.
+      or explicit user input; when optional and absent, the message omits
+      `Refs` entirely.
 - [ ] Required pre-commit hygiene checks from
       `references/commit-execution-policy.md` were run or explicitly blocked.
 - [ ] Execution result reports commit hash, test status, and remaining
@@ -271,7 +283,7 @@ issue mapping, and use review or CI skills for review/CI failures.
 
 ## Commit Message
 - subject:
-- refs:
+- refs: <omit this line when no verified reference exists>
 - preview:
 
 ## Execution Result
@@ -288,8 +300,11 @@ issue mapping, and use review or CI skills for review/CI failures.
   confirmation.
 - Do not continue to commit execution when `issue-gate-skill` returns `BLOCK`.
 - Do not write single-line commit messages.
-- Do not duplicate body sections; `Why`, `What`, `Impact`, `Tests`, and `Refs`
-  must each appear exactly once.
+- Do not duplicate body sections; `Why`, `What`, `Impact`, and `Tests` must each
+  appear exactly once, while `Refs` appears at most once when a verified
+  reference exists.
+- Do not render an empty `Refs` section or use `n/a`, `none`, or another
+  placeholder as traceability.
 - Do not create a second `Tests` section for another command; add another
   bullet under the existing `Tests` section.
 - Do not squash independent save points into one broad commit merely for speed.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Commit"
-  short_description: "v0.2.6 - Execute behavior-first Git commits with conditional references"
-  default_prompt: "Use $git-commit-skill to inspect staged evidence and recent repository language, split by concern, verify traceability, and execute each save-point commit with distinct behavior facts in the required Why/What/Impact/Tests sections, appending Refs only for a real verified reference while keeping command results in the execution report."
+  short_description: "v0.2.7 - Execute behavior-first Git commits with distinct impact and test evidence"
+  default_prompt: "Use $git-commit-skill to inspect staged evidence, split by concern, and execute each save-point commit with distinct Why/What/Impact/Tests facts: Impact states post-merge effects or preserved boundaries, Tests states actually verified conditions and expected results, and Refs appears only for a real verified reference."

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Commit"
-  short_description: "v0.2.5 - Execute behavior-first, traceable Git commits"
-  default_prompt: "Use $git-commit-skill to inspect staged evidence and recent repository language, split by concern, verify traceability, and execute each save-point commit with one distinct behavior fact in every required Why/What/Impact/Tests/Refs section while keeping command results in the execution report."
+  short_description: "v0.2.6 - Execute behavior-first Git commits with conditional references"
+  default_prompt: "Use $git-commit-skill to inspect staged evidence and recent repository language, split by concern, verify traceability, and execute each save-point commit with distinct behavior facts in the required Why/What/Impact/Tests sections, appending Refs only for a real verified reference while keeping command results in the execution report."

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Git Commit"
-  short_description: "v0.2.7 - Execute behavior-first Git commits with distinct impact and test evidence"
-  default_prompt: "Use $git-commit-skill to inspect staged evidence, split by concern, and execute each save-point commit with distinct Why/What/Impact/Tests facts: Impact states post-merge effects or preserved boundaries, Tests states actually verified conditions and expected results, and Refs appears only for a real verified reference."
+  short_description: "v0.2.8 - Execute concise Git commits with conditional evidence"
+  default_prompt: "Use $git-commit-skill to inspect staged evidence, split by concern, and execute each save-point commit with required Why/What plus Impact only for an independent consequence, Verification only for actual result-bearing evidence, and Refs only for a real verified reference."

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
@@ -5,8 +5,8 @@ message template.
 
 This policy intentionally follows
 `development-skill-pack/supporting-skills/git-workflow-and-versioning`.
-`commit-message-standard.md` is only the source of truth for the final
-`Why / What / Impact / Tests` message format and conditional `Refs` section.
+`commit-message-standard.md` is only the source of truth for the required
+`Why / What` core and conditional `Impact / Verification / Refs` sections.
 
 ## Default Execution Rule
 
@@ -170,8 +170,8 @@ Before every executed commit:
 2. Check the staged diff for obvious secrets or credentials.
 3. Run the most relevant tests or checks for the staged change.
 4. If tests/checks are not run, record the operational reason in the execution
-   report and state the unverified behavior boundary honestly in `Tests`; do
-   not invent a passing result.
+   report and omit `Verification`; do not invent a passing result or render a
+   placeholder section.
 5. Confirm generated files, lockfiles, snapshots, and schema outputs are
    expected by the repository before including them.
 
@@ -196,8 +196,8 @@ For each commit slice:
 2. Confirm the slice is one logical change and satisfies the size guidance.
 3. Stage only those files.
 4. Run pre-commit hygiene.
-5. Write the final commit message using `commit-message-standard.md`; keep
-   routine commands and pass or fail results in the execution report.
+5. Write the final commit message using `commit-message-standard.md`; keep raw
+   commands and detailed pass or fail output in the execution report.
 6. Run `git commit -F <file>`.
 7. Report commit hash, staged scope, tests, traceability status, and remaining
    unstaged scope.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-execution-policy.md
@@ -6,7 +6,7 @@ message template.
 This policy intentionally follows
 `development-skill-pack/supporting-skills/git-workflow-and-versioning`.
 `commit-message-standard.md` is only the source of truth for the final
-`Why / What / Impact / Tests / Refs` message format.
+`Why / What / Impact / Tests` message format and conditional `Refs` section.
 
 ## Default Execution Rule
 
@@ -73,8 +73,8 @@ discipline still applies when a team uses another branching model.
 - If the gate returns `BLOCK`, stop commit output and report the blocker.
 - If the gate returns `refs_line`, use it in `Refs` unless the repository has a
   stricter traceability rule.
-- If no issue requirement is found and the change is low risk, use
-  `Refs: n/a`.
+- If traceability is optional and no verified reference applies, omit the
+  entire `Refs` section.
 
 ## Atomic Commit Boundary Rules
 
@@ -199,8 +199,8 @@ For each commit slice:
 5. Write the final commit message using `commit-message-standard.md`; keep
    routine commands and pass or fail results in the execution report.
 6. Run `git commit -F <file>`.
-7. Report commit hash, staged scope, tests, `Refs`, and remaining unstaged
-   scope.
+7. Report commit hash, staged scope, tests, traceability status, and remaining
+   unstaged scope.
 
 If multiple commits are required, repeat these steps one slice at a time and
 show the remaining unstaged scope after each commit.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
@@ -9,6 +9,7 @@ Use this reference when writing or reviewing the actual commit message.
 - [Commit Message Format](#commit-message-format)
 - [Subject Rules](#subject-rules)
 - [Information Ownership](#information-ownership)
+  - [Impact And Tests Boundary](#impact-and-tests-boundary)
 - [Body Quality Bar](#body-quality-bar)
 - [Type Selection](#type-selection)
 - [Full Examples](#full-examples)
@@ -167,14 +168,44 @@ Assign each fact to one location before writing:
 | Subject | shortest recognizable action and object | identifiers, reasons, tests, impact details |
 | `Why` | one previous problem or trigger | test motivation, future speculation, solution details |
 | `What` | one resulting code, behavior, or document change | call-site counts, assertion lists, impact claims |
-| `Impact` | one observable effect or preserved boundary | repeated state tables, implementation details |
-| `Tests` | covered behavior or boundary and material expected result | commands, pass markers, test-file inventory |
+| `Impact` | post-merge observable effects, compatibility, and explicitly preserved boundaries | test commands, test files, verification steps |
+| `Tests` | conditions, scenarios, and expected results actually verified | generic "tested" claims, change benefits, repeated `Impact`, command-only lists |
 | `Refs` (conditional) | verified traceability | placeholders, extra explanation |
 | Execution report | commands, pass or fail results, skipped checks | behavior rationale |
 
 State each supporting detail once. Repeat the core behavior only when needed to
 connect `Why`, `What`, and `Impact`; do not repeat call-site counts, full state
 tables, function ownership, or test assertions merely because they are true.
+
+### Impact And Tests Boundary
+
+`Impact` states the consequence of merging the change. `Tests` states the
+evidence used to check the change. Tests may prove an impact, but they must add
+the exercised condition and expected result instead of restating the same
+consequence.
+
+Apply these independent-reader checks:
+
+1. Hide `Tests`. `Impact` must still identify who or what is affected, the
+   compatibility result, or the behavior explicitly preserved.
+2. Hide `Impact`. `Tests` must still identify the condition or scenario
+   exercised and the expected result.
+3. If one sentence can fill both sections unchanged, rewrite it. Keep the
+   post-merge consequence in `Impact` and the verification evidence in
+   `Tests`.
+
+For documentation and configuration changes, use the same boundary. `Impact`
+states what readers, operators, or consumers can rely on after the change.
+`Tests` records only an actual consistency, completeness, parsing, rendering,
+or other relevant check. Never invent a runtime behavior test for a static
+change.
+
+Example for a documented six-digit business-code contract:
+
+| Section | Example |
+|---|---|
+| `Impact` | `调用方可以按统一的六位数字格式处理业务码；现有请求字段和响应结构不变。` |
+| `Tests` | `公开契约与联调说明对合法六位码、位数错误和非数字字符给出一致的接受或拒绝结果。` |
 
 Write natural project language:
 
@@ -226,6 +257,8 @@ Write natural project language:
 - State migration, rollout, or compatibility consequences when they exist.
 - For a local rename, one short behavior-preservation statement is enough. Do
   not enumerate every state returned by the function.
+- Do not mention the test scenario or verification method; those belong in
+  `Tests`.
 
 ### Tests
 
@@ -238,6 +271,11 @@ Write natural project language:
 - If behavior verification did not run, state the unverified boundary and real
   reason honestly; keep command-level details in the execution report.
 - Do not claim that one test guarantees behavior beyond its exercised scenario.
+- Do not repeat the `Impact` consequence without adding the condition exercised
+  and expected result.
+- For documentation or configuration changes, name the static check that
+  actually established consistency or completeness; do not claim runtime
+  behavior was tested.
 
 ### Refs
 
@@ -462,6 +500,11 @@ Before accepting a message, confirm:
 - [ ] `Impact` names an observable result or precisely preserved boundary.
 - [ ] `Tests` states the behavior or boundary covered and includes the expected
       result when it is material, or honestly states the unverified boundary.
+- [ ] `Impact` remains meaningful without test context, while `Tests` remains
+      meaningful without impact context by naming an exercised condition and
+      expected result.
+- [ ] Documentation and configuration changes report only checks that actually
+      ran and do not invent runtime behavior verification.
 - [ ] Commands, pass or fail results, and skipped-check details stay in the
       execution report rather than the commit message.
 - [ ] `Refs` appears after `Tests` only when it contains verified traceability;

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
@@ -26,15 +26,17 @@ turn the diff into polished prose. Phrases such as "clarify responsibility,"
 "improve consistency," and "strengthen handling" describe desired qualities;
 they do not tell the reader what the commit did.
 
-The five required sections still form a story:
+The four required sections form the durable story. A verified reference extends
+that story when one exists:
 
 ```text
-previous problem -> concrete change -> observable result -> proof -> reference
-       Why              What              Impact       Tests      Refs
+previous problem -> concrete change -> observable result -> proof [-> reference]
+       Why              What              Impact       Tests       [Refs]
 ```
 
-Keep the structure visible. Improve readability by selecting one useful fact
-for each field, not by removing fields or rendering the entire evidence card.
+Keep the core structure visible. Improve readability by selecting one useful
+fact for each rendered field, not by rendering empty optional fields or the
+entire evidence card.
 
 ## Evidence Card
 
@@ -51,7 +53,7 @@ testing_boundary:
   expected: <result observed or asserted, when material>
   prevented: <incorrect behavior that did not occur, when material>
 execution_checks: <commands that ran, results, or skipped-check reason>
-refs: <verified issue/spec/incident/PR, or n/a when allowed>
+refs: <verified issue/spec/incident/PR; omit this key when none applies>
 ```
 
 `testing_boundary` supplies `Tests`. `execution_checks` belongs in CI or the
@@ -84,7 +86,7 @@ a symbol name that is not in the staged diff.
 
 ## Commit Message Format
 
-Use this exact structure:
+Use this exact core structure:
 
 ```text
 <type>(optional-scope): <subject>
@@ -100,16 +102,23 @@ Impact:
 
 Tests:
 - ...
+```
 
+When a real, verified reference exists, append:
+
+```text
 Refs:
 - ...
 ```
 
-This structure is mandatory. Do not add, omit, rename, or duplicate sections.
-When several independent behavior boundaries were tested, list them as
-separate bullets under the single `Tests` section. Use one bullet with one
-sentence in every section by default. Add another bullet only for a separate
-fact required to understand the commit.
+The four-section core is mandatory. Do not add, omit, rename, or duplicate its
+sections. `Refs` is conditional and may appear once after `Tests`; omit the
+entire section when no verified reference exists. Never render an empty `Refs`
+section or fill it with `n/a`, `none`, or another placeholder. When several
+independent behavior boundaries were tested, list them as separate bullets
+under the single `Tests` section. Use one bullet with one sentence in every
+rendered section by default. Add another bullet only for a separate fact
+required to understand the commit.
 
 ## Subject Rules
 
@@ -160,7 +169,7 @@ Assign each fact to one location before writing:
 | `What` | one resulting code, behavior, or document change | call-site counts, assertion lists, impact claims |
 | `Impact` | one observable effect or preserved boundary | repeated state tables, implementation details |
 | `Tests` | covered behavior or boundary and material expected result | commands, pass markers, test-file inventory |
-| `Refs` | verified traceability | extra explanation |
+| `Refs` (conditional) | verified traceability | placeholders, extra explanation |
 | Execution report | commands, pass or fail results, skipped checks | behavior rationale |
 
 State each supporting detail once. Repeat the core behavior only when needed to
@@ -235,8 +244,11 @@ Write natural project language:
 - Record verified decision and context references, not an attachment list.
 - If `issue-gate-skill` returned a `refs_line`, use it directly as the bullet
   content unless repository policy requires another representation.
-- Use `n/a` only when no canonical issue, spec, incident, or PR applies and
-  repository policy permits that fallback.
+- Omit the entire `Refs` section when no canonical issue, spec, incident, or PR
+  applies and repository policy does not require one.
+- If repository policy requires traceability but no verified reference exists,
+  block the commit instead of using a placeholder.
+- Never use `n/a`, `none`, an empty bullet, or similar filler.
 - Never invent a reference.
 
 ## Type Selection
@@ -330,16 +342,13 @@ Impact:
 
 Tests:
 - 环境变量表同时包含 CACHE_URL 的用途、示例值和启动所需说明。
-
-Refs:
-- n/a
 ```
 
 ### Repository-Language Contrasts
 
 The following scenarios are sanitized from recurring language patterns in a
 mature repository history. They teach wording only; this skill keeps its own
-required five-section structure.
+required four-section core and conditional `Refs` rule.
 
 | Section | Avoid | Prefer |
 |---|---|---|
@@ -412,6 +421,11 @@ complete, but the behavior transition is still unclear.
 
 ## Anti-Patterns
 
+| Traceability condition | Avoid | Required behavior |
+|---|---|---|
+| Optional and no verified reference exists. | Append `Refs:` with `n/a`, `none`, or an empty bullet. | Omit the entire `Refs` section. |
+| Required and no verified reference exists. | Use a placeholder so the commit can continue. | Block the commit and report the missing traceability. |
+
 | Evidence | Avoid | Prefer |
 |---|---|---|
 | Rename `restore_response_matrix_extract_status_from_cache`. | `refactor(response-check): 明确已完成缓存恢复职责` | `refactor(response-check): 重命名缓存恢复函数` |
@@ -441,8 +455,8 @@ Before accepting a message, confirm:
 - [ ] The staged diff supports the selected type and scope.
 - [ ] The subject contains a concrete action and real object.
 - [ ] The subject passes all four reader checks.
-- [ ] The message contains exactly one `Why`, `What`, `Impact`, `Tests`, and
-      `Refs` section in that order.
+- [ ] The message contains exactly one `Why`, `What`, `Impact`, and `Tests`
+      section in that order.
 - [ ] `Why` names the previous problem or trigger.
 - [ ] `What` names the actual behavior or structural change.
 - [ ] `Impact` names an observable result or precisely preserved boundary.
@@ -450,7 +464,8 @@ Before accepting a message, confirm:
       result when it is material, or honestly states the unverified boundary.
 - [ ] Commands, pass or fail results, and skipped-check details stay in the
       execution report rather than the commit message.
-- [ ] `Refs` contains only verified traceability or an allowed `n/a` fallback.
+- [ ] `Refs` appears after `Tests` only when it contains verified traceability;
+      otherwise the entire section is absent.
 - [ ] `Why -> What -> Impact` reads as one causal chain.
 - [ ] Each supporting detail appears in its owning location only.
 - [ ] Every section has one bullet unless another independent fact is required.

--- a/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
+++ b/agent-specs/engineering/skills/delivery-workflow/git-commit-skill/references/commit-message-standard.md
@@ -9,7 +9,7 @@ Use this reference when writing or reviewing the actual commit message.
 - [Commit Message Format](#commit-message-format)
 - [Subject Rules](#subject-rules)
 - [Information Ownership](#information-ownership)
-  - [Impact And Tests Boundary](#impact-and-tests-boundary)
+  - [Conditional Impact And Verification](#conditional-impact-and-verification)
 - [Body Quality Bar](#body-quality-bar)
 - [Type Selection](#type-selection)
 - [Full Examples](#full-examples)
@@ -20,24 +20,25 @@ Use this reference when writing or reviewing the actual commit message.
 
 A commit message is the shortest complete account of one staged change for a
 future engineer reading history. It must identify the observable change,
-explain the reason, record its boundary and proof, and preserve traceability.
+explain the reason, and preserve only useful boundary, proof, and traceability
+evidence.
 
 The task is not to praise the change, summarize the author's intention, or
 turn the diff into polished prose. Phrases such as "clarify responsibility,"
 "improve consistency," and "strengthen handling" describe desired qualities;
 they do not tell the reader what the commit did.
 
-The four required sections form the durable story. A verified reference extends
-that story when one exists:
+The required `Why / What` core forms the durable story. Conditional sections
+extend it only when they add independent information:
 
 ```text
-previous problem -> concrete change -> observable result -> proof [-> reference]
-       Why              What              Impact       Tests       [Refs]
+previous problem -> concrete change [-> independent effect] [-> evidence] [-> reference]
+       Why              What              [Impact]       [Verification]   [Refs]
 ```
 
-Keep the core structure visible. Improve readability by selecting one useful
-fact for each rendered field, not by rendering empty optional fields or the
-entire evidence card.
+Keep the two-section core visible. Improve readability by selecting one useful
+fact for each rendered field, not by filling every conditional section or
+rendering the entire evidence card.
 
 ## Evidence Card
 
@@ -48,25 +49,25 @@ primary_action: <rename | extract | move | remove | add | prevent | ...>
 primary_object: <behavior, symbol, document, contract, or state transition>
 before: <specific previous behavior, ambiguity, failure, or request>
 after: <specific resulting behavior or structure>
-impact_boundary: <observable effect or behavior explicitly preserved>
-testing_boundary:
-  coverage: <behavior, scenario, or boundary exercised>
-  expected: <result observed or asserted, when material>
-  prevented: <incorrect behavior that did not occur, when material>
+impact_boundary: <independent effect or preserved boundary; omit when none>
+verification_boundary:
+  suite_outcome: <relevant suite name, total, and result when useful>
+  condition_result: <checked condition and observed result>
 execution_checks: <commands that ran, results, or skipped-check reason>
 refs: <verified issue/spec/incident/PR; omit this key when none applies>
 ```
 
-`testing_boundary` supplies `Tests`. `execution_checks` belongs in CI or the
-execution report. Do not turn it into `PASS: <command>` commit prose.
+`verification_boundary` supplies `Verification` only when it contains durable
+result evidence. `execution_checks` belongs in CI or the execution report. Do
+not turn it into `PASS: <command>` commit prose.
 
 Use these sources in this order:
 
 1. The staged diff is authoritative for the action, object, and contained
    behavior.
 2. The issue or user request supplies the trigger and intended outcome.
-3. Tests establish verified behavior; they do not justify claims they do not
-   exercise.
+3. Executed checks establish verified behavior; they do not justify claims they
+   do not exercise.
 4. Recent repository history supplies concrete verbs, behavior phrasing, and
    project vocabulary when those patterns are consistent.
 5. Repository conventions determine type, scope, and reference syntax.
@@ -87,7 +88,7 @@ a symbol name that is not in the staged diff.
 
 ## Commit Message Format
 
-Use this exact core structure:
+Use this exact required core:
 
 ```text
 <type>(optional-scope): <subject>
@@ -97,29 +98,29 @@ Why:
 
 What:
 - ...
+```
 
+Append supported conditional sections in this order:
+
+```text
 Impact:
 - ...
 
-Tests:
+Verification:
 - ...
-```
 
-When a real, verified reference exists, append:
-
-```text
 Refs:
 - ...
 ```
 
-The four-section core is mandatory. Do not add, omit, rename, or duplicate its
-sections. `Refs` is conditional and may appear once after `Tests`; omit the
-entire section when no verified reference exists. Never render an empty `Refs`
+`Why` and `What` are mandatory and appear exactly once. `Impact`,
+`Verification`, and `Refs` are conditional and appear at most once. Omit a
+conditional section when it has no independent evidence; never render an empty
 section or fill it with `n/a`, `none`, or another placeholder. When several
-independent behavior boundaries were tested, list them as separate bullets
-under the single `Tests` section. Use one bullet with one sentence in every
-rendered section by default. Add another bullet only for a separate fact
-required to understand the commit.
+verification results matter, list them as bullets under the single
+`Verification` section. Use one bullet with one sentence in every rendered
+section by default. Add another bullet only for a separate fact required to
+understand the commit.
 
 ## Subject Rules
 
@@ -168,44 +169,49 @@ Assign each fact to one location before writing:
 | Subject | shortest recognizable action and object | identifiers, reasons, tests, impact details |
 | `Why` | one previous problem or trigger | test motivation, future speculation, solution details |
 | `What` | one resulting code, behavior, or document change | call-site counts, assertion lists, impact claims |
-| `Impact` | post-merge observable effects, compatibility, and explicitly preserved boundaries | test commands, test files, verification steps |
-| `Tests` | conditions, scenarios, and expected results actually verified | generic "tested" claims, change benefits, repeated `Impact`, command-only lists |
+| `Impact` (conditional) | independent post-merge effects, compatibility, and explicitly preserved boundaries | restated `What`, test commands, verification steps |
+| `Verification` (conditional) | useful suite outcomes or checked conditions paired with observed results | bare coverage inventories, raw commands, `PASS:` prefixes, repeated `Impact` |
 | `Refs` (conditional) | verified traceability | placeholders, extra explanation |
-| Execution report | commands, pass or fail results, skipped checks | behavior rationale |
+| Execution report | raw commands, detailed pass or fail output, skipped checks | behavior rationale |
 
 State each supporting detail once. Repeat the core behavior only when needed to
-connect `Why`, `What`, and `Impact`; do not repeat call-site counts, full state
-tables, function ownership, or test assertions merely because they are true.
+connect `Why` and `What`; do not repeat call-site counts, full state tables,
+function ownership, or assertions merely because they are true.
 
-### Impact And Tests Boundary
+### Conditional Impact And Verification
 
-`Impact` states the consequence of merging the change. `Tests` states the
-evidence used to check the change. Tests may prove an impact, but they must add
-the exercised condition and expected result instead of restating the same
-consequence.
+`Impact` states an independent consequence of merging the change.
+`Verification` states durable evidence used to check the change. Neither
+section exists merely to complete the template.
 
-Apply these independent-reader checks:
+Apply these rendering checks:
 
-1. Hide `Tests`. `Impact` must still identify who or what is affected, the
-   compatibility result, or the behavior explicitly preserved.
-2. Hide `Impact`. `Tests` must still identify the condition or scenario
-   exercised and the expected result.
-3. If one sentence can fill both sections unchanged, rewrite it. Keep the
-   post-merge consequence in `Impact` and the verification evidence in
-   `Tests`.
+1. Hide `Impact`. If `What` loses no independent consequence, omit `Impact`.
+2. Hide `Verification`. If no useful suite outcome, checked condition, or
+   observed result disappears, omit `Verification`.
+3. If one sentence can fill both sections unchanged, keep the consequence in
+   `Impact` and the evidence in `Verification`, or omit the redundant section.
 
 For documentation and configuration changes, use the same boundary. `Impact`
 states what readers, operators, or consumers can rely on after the change.
-`Tests` records only an actual consistency, completeness, parsing, rendering,
-or other relevant check. Never invent a runtime behavior test for a static
-change.
+`Verification` records only an actual consistency, completeness, parsing,
+rendering, or other relevant result. Never invent a runtime behavior check for
+a static change.
 
 Example for a documented six-digit business-code contract:
 
 | Section | Example |
 |---|---|
 | `Impact` | `调用方可以按统一的六位数字格式处理业务码；现有请求字段和响应结构不变。` |
-| `Tests` | `公开契约与联调说明对合法六位码、位数错误和非数字字符给出一致的接受或拒绝结果。` |
+| `Verification` | `公开契约与联调说明对合法六位码、位数错误和非数字字符给出一致的接受或拒绝结果。` |
+
+A concise suite outcome and a measured representative sample are also valid:
+
+```text
+Verification:
+- 源文档服务、响应矩阵抽取和源表物化的 50 项相关测试全部通过。
+- 真实公告转换后，Markdown 从 518,705 字符降至 4,828 字符，且不再包含 data:image 或 base64,。
+```
 
 Write natural project language:
 
@@ -240,14 +246,16 @@ Write natural project language:
   under the internal-detail rule.
 - When both rename identifiers are long, name only the new identifier; the diff
   already records the old one.
-- Every bullet must be supported by the staged diff or tests.
-- Leave test additions and assertions to `Tests` unless tests are the primary
-  change.
+- Every bullet must be supported by the staged diff or verification evidence.
+- Leave suite outcomes and observed results to `Verification` unless tests are
+  the primary change.
 - Do not report how many call sites were updated; a rename already implies
   updating its callers.
 
 ### Impact
 
+- Omit this section when `What` already carries the full result and no separate
+  consequence or preserved boundary remains.
 - State the observable user, interface, runtime, release, or maintenance
   boundary.
 - For a behavior-preserving refactor, identify the behavior that remains
@@ -257,22 +265,23 @@ Write natural project language:
 - State migration, rollout, or compatibility consequences when they exist.
 - For a local rename, one short behavior-preservation statement is enough. Do
   not enumerate every state returned by the function.
-- Do not mention the test scenario or verification method; those belong in
-  `Tests`.
+- Do not mention the checked scenario or verification method; those belong in
+  `Verification`.
 
-### Tests
+### Verification Section
 
-- State the behavior, scenario, or boundary covered.
-- Use a compact coverage list when `What` already makes the expected result
-  clear, such as "cover safe and ambiguous path forms." Add the expected result
-  when the prevented regression is the important fact.
-- Do not list commands, `PASS`, test file names, or "added a regression test."
-  Those describe execution or the diff, not the behavior protected.
-- If behavior verification did not run, state the unverified boundary and real
-  reason honestly; keep command-level details in the execution report.
-- Do not claim that one test guarantees behavior beyond its exercised scenario.
-- Do not repeat the `Impact` consequence without adding the condition exercised
-  and expected result.
+- Render this section only for actual, useful result evidence.
+- Record either a concise relevant suite outcome, including its total when
+  useful, or a checked condition paired with the observed result.
+- Reject noun lists such as "cover images, cache invalidation, extraction, and
+  materialization boundaries." They name areas, not verified outcomes.
+- Do not list raw commands, `PASS:` prefixes, test file names, or "added a
+  regression test." Those describe execution or the diff, not durable evidence.
+- If verification did not run or produced no useful result, omit this section
+  and keep the operational reason in the execution report.
+- Do not claim that one check guarantees behavior beyond its exercised scenario.
+- Do not repeat the `Impact` consequence without adding a suite outcome or
+  checked condition and observed result.
 - For documentation or configuration changes, name the static check that
   actually established consistency or completeness; do not claim runtime
   behavior was tested.
@@ -333,7 +342,7 @@ What:
 Impact:
 - 缓存恢复和响应检查行为不变。
 
-Tests:
+Verification:
 - 空矩阵缓存仍恢复为 completed，缓存缺失仍返回 None。
 
 Refs:
@@ -357,14 +366,14 @@ What:
 Impact:
 - 命中空矩阵缓存的任务不再被错误标记为抽取失败。
 
-Tests:
+Verification:
 - 空矩阵缓存恢复为 completed，不再进入抽取失败结果。
 
 Refs:
 - ISSUE: #168
 ```
 
-### Documentation Change Without External Reference
+### Minimal Documentation Change
 
 ```text
 docs(onboarding): 补充本地启动所需环境变量
@@ -374,34 +383,25 @@ Why:
 
 What:
 - 在本地环境变量表中补充 CACHE_URL 的用途和示例值。
-
-Impact:
-- 读者可以仅按入门文档完成本地配置；运行时代码不变。
-
-Tests:
-- 环境变量表同时包含 CACHE_URL 的用途、示例值和启动所需说明。
 ```
 
 ### Repository-Language Contrasts
 
 The following scenarios are sanitized from recurring language patterns in a
 mature repository history. They teach wording only; this skill keeps its own
-required four-section core and conditional `Refs` rule.
+required `Why / What` core and conditional section rules.
 
 | Section | Avoid | Prefer |
 |---|---|---|
 | `Why` | `The metadata sources need better consistency.` | `A saved working directory can become stale after thread metadata changes, so reads and lists report different locations.` |
 | `What` | `Update the state overlay and recompute internal metadata.` | `Prefer the persisted working directory when it belongs to the requested thread, while retaining the saved fallback for older records.` |
 | `Impact` | `This improves thread reliability.` | `Thread reads and lists now agree on the saved location; older records without one keep their previous behavior.` |
-| `Tests` | `PASS: cargo test -p core thread_read` | `Stale and empty saved locations select the expected value, while a resumed thread still uses its requested live location.` |
-| `Tests` | `Add regression coverage for path handling.` | `Cover safe and ambiguous path forms, encoded traversal, and hosts that require inspection.` |
+| `Verification` | `PASS: cargo test -p core thread_read` | `Stale and empty saved locations select the expected value, while a resumed thread still uses its requested live location.` |
+| `Verification` | `Add regression coverage for path handling.` | `Safe path forms remain allowed, encoded traversal is rejected, and ambiguous hosts require inspection.` |
 
-The two preferred `Tests` forms are both valid:
-
-- `Cover ...` names a compact behavior boundary when the expected result is
-  already clear from `What`.
-- A full behavior assertion names the result when that result is the regression
-  future readers need to retain.
+Both preferred `Verification` examples name checked conditions and observed
+results. A `Cover ...` phrase followed only by a list is invalid even when
+`What` already states the intended behavior.
 
 ### Complete Behavior-First Example
 
@@ -420,7 +420,7 @@ Impact:
 - An allowed path cannot be reinterpreted as another resource; ordinary safe
   paths keep their previous behavior.
 
-Tests:
+Verification:
 - Safe paths remain allowed, while ambiguous paths are rejected before they can
   reach another resource.
 
@@ -446,7 +446,7 @@ What:
 Impact:
 - Authorization is safer and more reliable.
 
-Tests:
+Verification:
 - PASS: cargo test -p network-proxy authorization
 
 Refs:
@@ -454,8 +454,8 @@ Refs:
 ```
 
 The subject states a quality, `Why` is generic, `What` narrates the diff,
-`Impact` is unsupported, and `Tests` is an execution log. The structure is
-complete, but the behavior transition is still unclear.
+`Impact` is unsupported, and `Verification` is a raw execution log. Optional
+sections do not make the behavior transition clearer.
 
 ## Anti-Patterns
 
@@ -463,6 +463,10 @@ complete, but the behavior transition is still unclear.
 |---|---|---|
 | Optional and no verified reference exists. | Append `Refs:` with `n/a`, `none`, or an empty bullet. | Omit the entire `Refs` section. |
 | Required and no verified reference exists. | Use a placeholder so the commit can continue. | Block the commit and report the missing traceability. |
+
+| Verification evidence | Avoid | Required behavior |
+|---|---|---|
+| Results exist for converted images and stale caches, but other areas have no recorded outcome. | `覆盖内嵌和链接图片、旧缓存失效、真实公告转换、响应矩阵抽取及源表物化边界。` | State that converted images remain accessible and stale caches regenerate instead of reusing old results; omit the other claims and keep missing-check reasons in the execution report. |
 
 | Evidence | Avoid | Prefer |
 |---|---|---|
@@ -481,10 +485,10 @@ For the behavior-preserving rename example, reject this overloaded body shape:
 | Section | Avoid | Prefer |
 |---|---|---|
 | `Why` | `空矩阵也是有效缓存结果，需要用测试固定其完成态边界，避免后续重新引入失败状态判断。` | `原名称暗示会恢复所有抽取状态，实际只处理 completed 缓存结果。` |
-| `What` | `同步两处工作流调用，并验证 completed、100% 且无错误。` | State the rename once; report the check under `Tests`. |
+| `What` | `同步两处工作流调用，并验证 completed、100% 且无错误。` | State the rename once; report the result under `Verification`. |
 | `Impact` | `成功和空矩阵返回 completed，缺失缓存返回 None；运行时抽取失败仍写入 error。` | `缓存恢复和响应检查行为不变。` |
-| `Tests` | `PASS: pytest ...` | `空矩阵缓存仍恢复为 completed，缓存缺失仍返回 None。` |
-| `Tests` | `增加空矩阵回归测试。` | `空矩阵缓存恢复为 completed，不再进入抽取失败结果。` |
+| `Verification` | `PASS: pytest ...` | `空矩阵缓存仍恢复为 completed，缓存缺失仍返回 None。` |
+| `Verification` | `增加空矩阵回归测试。` | `空矩阵缓存恢复为 completed，不再进入抽取失败结果。` |
 
 ## Verification
 
@@ -493,25 +497,25 @@ Before accepting a message, confirm:
 - [ ] The staged diff supports the selected type and scope.
 - [ ] The subject contains a concrete action and real object.
 - [ ] The subject passes all four reader checks.
-- [ ] The message contains exactly one `Why`, `What`, `Impact`, and `Tests`
-      section in that order.
+- [ ] The message contains exactly one `Why` and `What`; conditional `Impact`,
+      `Verification`, and `Refs` appear at most once in that order.
 - [ ] `Why` names the previous problem or trigger.
 - [ ] `What` names the actual behavior or structural change.
-- [ ] `Impact` names an observable result or precisely preserved boundary.
-- [ ] `Tests` states the behavior or boundary covered and includes the expected
-      result when it is material, or honestly states the unverified boundary.
-- [ ] `Impact` remains meaningful without test context, while `Tests` remains
-      meaningful without impact context by naming an exercised condition and
-      expected result.
+- [ ] `Impact`, when present, adds an independent observable consequence or
+      precisely preserved boundary beyond `What`.
+- [ ] `Verification`, when present, records an actual suite outcome or checked
+      condition with an observed result.
 - [ ] Documentation and configuration changes report only checks that actually
       ran and do not invent runtime behavior verification.
-- [ ] Commands, pass or fail results, and skipped-check details stay in the
+- [ ] Raw commands, `PASS:` markers, and skipped-check details stay in the
       execution report rather than the commit message.
-- [ ] `Refs` appears after `Tests` only when it contains verified traceability;
-      otherwise the entire section is absent.
-- [ ] `Why -> What -> Impact` reads as one causal chain.
+- [ ] `Refs` appears after the other rendered conditional sections only when it
+      contains verified traceability; otherwise it is absent.
+- [ ] `Why -> What` reads as one causal chain and each conditional section
+      extends it with independent information.
 - [ ] Each supporting detail appears in its owning location only.
-- [ ] Every section has one bullet unless another independent fact is required.
+- [ ] Every rendered section has one bullet unless another independent fact is
+      required.
 - [ ] The message uses established project terms and no coined noun stack.
 - [ ] Internal identifiers appear only when they carry public contract,
       change-object, or state-transition meaning.

--- a/agent-specs/engineering/skills/delivery-workflow/single-doc-checkpoint-commit-skill/SKILL.md
+++ b/agent-specs/engineering/skills/delivery-workflow/single-doc-checkpoint-commit-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: single-doc-checkpoint-commit-skill
-description: v0.1.0 - Commit exactly one tutorial or learning document checkpoint with structured freeze metadata. Use when a single Markdown learning document has reached one verified Freeze/Checkpoint and the document body should stay reader-friendly while Pressure/Naive/Break/Change/Check/Freeze/Still-lacks/Next are recorded in the Git commit message.
+description: v0.1.1 - Commit exactly one tutorial or learning document checkpoint with structured freeze metadata. Use when a single Markdown learning document has reached one verified Freeze/Checkpoint and the document body should stay reader-friendly while Pressure/Naive/Break/Change/Check/Freeze/Still-lacks/Next are recorded in the Git commit message.
 ---
 
 # Single Doc Checkpoint Commit Skill
@@ -169,9 +169,8 @@ Next:
 - ...
 ```
 
-Do not use the normal `Why / What / Impact / Tests / Refs` body for this
-skill. The checkpoint body is the source of truth for learning-history
-traceability.
+Do not use the normal `git-commit-skill` body for this skill. The checkpoint
+body is the source of truth for learning-history traceability.
 
 ## Common Rationalizations
 
@@ -244,7 +243,7 @@ traceability.
 - Do not stage code or generated files.
 - Do not use `git add .`.
 - Do not write a one-line checkpoint commit.
-- Do not use `Why / What / Impact / Tests / Refs` for this skill.
+- Do not use the normal `git-commit-skill` body for this skill.
 - Do not commit when required checkpoint fields are missing.
 - Do not let internal tutorial fields leak into public prose as a workaround
   for a weak commit message.

--- a/agent-specs/engineering/skills/delivery-workflow/single-doc-checkpoint-commit-skill/agents/openai.yaml
+++ b/agent-specs/engineering/skills/delivery-workflow/single-doc-checkpoint-commit-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Single Doc Checkpoint Commit"
-  short_description: "v0.1.0 - Commit one learning document checkpoint"
+  short_description: "v0.1.1 - Commit one learning document checkpoint"
   default_prompt: "Use $single-doc-checkpoint-commit-skill to commit exactly one tutorial or learning document checkpoint. Stage only the target document, keep template fields out of the public document body, and record Pressure/Naive/Break/Change/Check/Freeze/Still lacks/Next in the commit message."


### PR DESCRIPTION
## Summary

- Keep `Why` and `What` mandatory while rendering `Impact`, `Verification`, and `Refs` only when each section adds independent information.
- Replace the fixed `Tests` block with conditional `Verification` that accepts concise suite outcomes and measured results while rejecting commands and bare coverage lists.
- Synchronize repository guidance, execution policy, examples, metadata, and the specialized checkpoint skill with the same contract.

## Why

Fixed body sections made small commits repeat the same result or add low-signal filler. In particular, coverage inventories such as a list of affected components did not tell future readers what condition was checked or what result was observed.

## Verification

- Minimal `Why/What`, `Why/What/Verification`, and full message fixtures accept the intended section combinations.
- Skill versions and OpenAI metadata are synchronized, and the metadata YAML parses successfully.
- Repository scans find no legacy fixed `Why/What/Impact/Tests` contract; diff-format and credential checks are clean.
- A three-way merge check against the latest `upstream/main` completes without conflicts.

Refs #23
